### PR TITLE
Expose C bindings for Checkpoint::ExportColumnFamily

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -241,9 +241,6 @@ struct rocksdb_column_family_metadata_t {
 struct rocksdb_export_import_files_metadata_t {
   ExportImportFilesMetaData* rep;
 };
-struct rocksdb_live_file_metadata_t {
-  LiveFileMetaData* rep;
-};
 struct rocksdb_import_column_family_options_t {
   ImportColumnFamilyOptions rep;
 };
@@ -5962,6 +5959,8 @@ void rocksdb_export_import_files_metadata_destroy(
   delete metadata->rep;
   delete metadata;
 }
+
+/* Transactions */
 
 rocksdb_transactiondb_options_t* rocksdb_transactiondb_options_create() {
   return new rocksdb_transactiondb_options_t;

--- a/db/c.cc
+++ b/db/c.cc
@@ -228,6 +228,9 @@ struct rocksdb_cache_t {
 struct rocksdb_write_buffer_manager_t {
   std::shared_ptr<WriteBufferManager> rep;
 };
+struct rocksdb_livefile_t {
+  LiveFileMetaData rep;
+};
 struct rocksdb_livefiles_t {
   std::vector<LiveFileMetaData> rep;
 };
@@ -5730,29 +5733,6 @@ rocksdb_livefiles_t* rocksdb_livefiles_create() {
   return new rocksdb_livefiles_t;
 }
 
-void rocksdb_livefiles_add(rocksdb_livefiles_t* lf,
-                           const char* column_family_name, const char* name,
-                           const char* directory, size_t size, int level,
-                           const char* start_key, size_t start_key_len,
-                           const char* end_key, size_t end_key_len,
-                           uint64_t smallest_seqno, uint64_t largest_seqno,
-                           uint64_t num_entries, uint64_t num_deletions) {
-  LiveFileMetaData file_meta;
-  file_meta.column_family_name = std::string(column_family_name);
-  file_meta.name = std::string(name);
-  file_meta.directory = std::string(directory);
-  file_meta.db_path = std::string(directory); // deprecated
-  file_meta.size = size;
-  file_meta.level = level;
-  file_meta.smallestkey = std::string(start_key, start_key_len);
-  file_meta.largestkey = std::string(end_key, end_key_len);
-  file_meta.smallest_seqno = smallest_seqno;
-  file_meta.largest_seqno = largest_seqno;
-  file_meta.num_entries = num_entries;
-  file_meta.num_deletions = num_deletions;
-  lf->rep.push_back(std::move(file_meta));
-}
-
 int rocksdb_livefiles_count(const rocksdb_livefiles_t* lf) {
   return static_cast<int>(lf->rep.size());
 }
@@ -5813,6 +5793,64 @@ uint64_t rocksdb_livefiles_deletions(const rocksdb_livefiles_t* lf, int index) {
 }
 
 void rocksdb_livefiles_destroy(const rocksdb_livefiles_t* lf) { delete lf; }
+
+rocksdb_livefile_t* rocksdb_livefile_create() {
+  return new rocksdb_livefile_t;
+}
+
+void rocksdb_livefile_set_column_family_name(rocksdb_livefile_t* lf, const char* column_family_name) {
+  lf->rep.column_family_name = std::string(column_family_name);
+}
+
+void rocksdb_livefile_set_level(rocksdb_livefile_t* lf, int level) {
+  lf->rep.level = level;
+}
+
+void rocksdb_livefile_set_name(rocksdb_livefile_t* lf, const char* name) {
+  lf->rep.name = std::string(name);
+}
+
+void rocksdb_livefile_set_directory(rocksdb_livefile_t* lf, const char* directory) {
+  lf->rep.directory = std::string(directory);
+  lf->rep.db_path = std::string(directory); // deprecated but necessary
+}
+
+void rocksdb_livefile_set_size(rocksdb_livefile_t* lf, size_t size) {
+  lf->rep.size = size;
+}
+
+void rocksdb_livefile_set_smallest_key(rocksdb_livefile_t* lf, const char* smallest_key, size_t smallest_key_len) {
+  lf->rep.smallestkey = std::string(smallest_key, smallest_key_len);
+}
+
+void rocksdb_livefile_set_largest_key(rocksdb_livefile_t* lf, const char* largest_key, size_t largest_key_len) {
+  lf->rep.largestkey = std::string(largest_key, largest_key_len);
+}
+
+void rocksdb_livefile_set_smallest_seqno(rocksdb_livefile_t* lf, uint64_t smallest_seqno) {
+  lf->rep.smallest_seqno = smallest_seqno;
+}
+
+void rocksdb_livefile_set_largest_seqno(rocksdb_livefile_t* lf, uint64_t largest_seqno) {
+  lf->rep.largest_seqno = largest_seqno;
+}
+
+void rocksdb_livefile_set_num_entries(rocksdb_livefile_t* lf, uint64_t num_entries) {
+  lf->rep.num_entries = num_entries;
+}
+
+void rocksdb_livefile_set_num_deletions(rocksdb_livefile_t* lf, uint64_t num_deletions) {
+  lf->rep.num_deletions = num_deletions;
+}
+
+void rocksdb_livefile_destroy(rocksdb_livefile_t* lf) {
+  delete lf;
+}
+
+void rocksdb_livefiles_add(rocksdb_livefiles_t* lf, rocksdb_livefile_t* livefile) {
+  lf->rep.push_back(std::move(livefile->rep));
+  delete livefile;
+}
 
 void rocksdb_get_options_from_string(const rocksdb_options_t* base_options,
                                      const char* opts_str,

--- a/db/c.cc
+++ b/db/c.cc
@@ -76,11 +76,13 @@ using ROCKSDB_NAMESPACE::DBOptions;
 using ROCKSDB_NAMESPACE::DbPath;
 using ROCKSDB_NAMESPACE::Env;
 using ROCKSDB_NAMESPACE::EnvOptions;
+using ROCKSDB_NAMESPACE::ExportImportFilesMetaData;
 using ROCKSDB_NAMESPACE::FileLock;
 using ROCKSDB_NAMESPACE::FilterPolicy;
 using ROCKSDB_NAMESPACE::FlushOptions;
 using ROCKSDB_NAMESPACE::HistogramData;
 using ROCKSDB_NAMESPACE::HyperClockCacheOptions;
+using ROCKSDB_NAMESPACE::ImportColumnFamilyOptions;
 using ROCKSDB_NAMESPACE::InfoLogLevel;
 using ROCKSDB_NAMESPACE::IngestExternalFileOptions;
 using ROCKSDB_NAMESPACE::Iterator;
@@ -235,6 +237,15 @@ struct rocksdb_column_family_handle_t {
 };
 struct rocksdb_column_family_metadata_t {
   ColumnFamilyMetaData rep;
+};
+struct rocksdb_export_import_files_metadata_t {
+  ExportImportFilesMetaData* rep;
+};
+struct rocksdb_live_file_metadata_t {
+  LiveFileMetaData* rep;
+};
+struct rocksdb_import_column_family_options_t {
+  ImportColumnFamilyOptions rep;
 };
 struct rocksdb_level_metadata_t {
   const LevelMetaData* rep;
@@ -902,6 +913,22 @@ void rocksdb_checkpoint_create(rocksdb_checkpoint_t* checkpoint,
                         std::string(checkpoint_dir), log_size_for_flush));
 }
 
+rocksdb_export_import_files_metadata_t* rocksdb_checkpoint_export_column_family(
+    rocksdb_checkpoint_t* checkpoint,
+    rocksdb_column_family_handle_t* column_family, const char* export_dir,
+    char** errptr) {
+  ExportImportFilesMetaData* metadata;
+  if (SaveError(errptr,
+                checkpoint->rep->ExportColumnFamily(
+                    column_family->rep, std::string(export_dir), &metadata))) {
+    return nullptr;
+  }
+  rocksdb_export_import_files_metadata_t* result =
+      new rocksdb_export_import_files_metadata_t;
+  result->rep = metadata;
+  return result;
+}
+
 void rocksdb_checkpoint_object_destroy(rocksdb_checkpoint_t* checkpoint) {
   delete checkpoint->rep;
   delete checkpoint;
@@ -1143,6 +1170,20 @@ rocksdb_column_family_handle_t** rocksdb_create_column_families(
   }
 
   return c_handles;
+}
+
+rocksdb_column_family_handle_t* rocksdb_create_column_family_with_import(
+    rocksdb_t* db, rocksdb_options_t* column_family_options,
+    const char* column_family_name,
+    rocksdb_import_column_family_options_t* import_options,
+    rocksdb_export_import_files_metadata_t* export_import_files_metadata,
+    char** errptr) {
+  rocksdb_column_family_handle_t* handle = new rocksdb_column_family_handle_t;
+  SaveError(errptr, db->rep->CreateColumnFamilyWithImport(
+                        ColumnFamilyOptions(column_family_options->rep),
+                        std::string(column_family_name), import_options->rep,
+                        *(export_import_files_metadata->rep), &(handle->rep)));
+  return handle;
 }
 
 void rocksdb_create_column_families_destroy(
@@ -5632,6 +5673,33 @@ void rocksdb_options_set_min_level_to_compress(rocksdb_options_t* opt,
   }
 }
 
+rocksdb_livefiles_t* rocksdb_livefiles_create() {
+  return new rocksdb_livefiles_t;
+}
+
+void rocksdb_livefiles_add(rocksdb_livefiles_t* lf,
+                           const char* column_family_name, const char* name,
+                           const char* directory, size_t size, int level,
+                           const char* start_key, size_t start_key_len,
+                           const char* end_key, size_t end_key_len,
+                           uint64_t smallest_seqno, uint64_t largest_seqno,
+                           uint64_t num_entries, uint64_t num_deletions) {
+  LiveFileMetaData file_meta;
+  file_meta.column_family_name = std::string(column_family_name);
+  file_meta.name = std::string(name);
+  file_meta.directory = std::string(directory);
+  file_meta.db_path = std::string(directory); // deprecated
+  file_meta.size = size;
+  file_meta.level = level;
+  file_meta.smallestkey = std::string(start_key, start_key_len);
+  file_meta.largestkey = std::string(end_key, end_key_len);
+  file_meta.smallest_seqno = smallest_seqno;
+  file_meta.largest_seqno = largest_seqno;
+  file_meta.num_entries = num_entries;
+  file_meta.num_deletions = num_deletions;
+  lf->rep.push_back(std::move(file_meta));
+}
+
 int rocksdb_livefiles_count(const rocksdb_livefiles_t* lf) {
   return static_cast<int>(lf->rep.size());
 }
@@ -5643,6 +5711,16 @@ const char* rocksdb_livefiles_column_family_name(const rocksdb_livefiles_t* lf,
 
 const char* rocksdb_livefiles_name(const rocksdb_livefiles_t* lf, int index) {
   return lf->rep[index].name.c_str();
+}
+
+const char* rocksdb_livefiles_directory(const rocksdb_livefiles_t* lf,
+                                        int index) {
+  if (lf->rep[index].directory.empty()) {
+    // db_path is deprecated but still returned by some code paths
+    return lf->rep[index].db_path.c_str();
+  } else {
+    return lf->rep[index].directory.c_str();
+  }
 }
 
 int rocksdb_livefiles_level(const rocksdb_livefiles_t* lf, int index) {
@@ -5663,6 +5741,14 @@ const char* rocksdb_livefiles_largestkey(const rocksdb_livefiles_t* lf,
                                          int index, size_t* size) {
   *size = lf->rep[index].largestkey.size();
   return lf->rep[index].largestkey.data();
+}
+
+uint64_t rocksdb_livefiles_smallest_seqno(const rocksdb_livefiles_t* lf, int index) {
+  return lf->rep[index].smallest_seqno;
+}
+
+uint64_t rocksdb_livefiles_largest_seqno(const rocksdb_livefiles_t* lf, int index) {
+  return lf->rep[index].largest_seqno;
 }
 
 uint64_t rocksdb_livefiles_entries(const rocksdb_livefiles_t* lf, int index) {
@@ -5825,7 +5911,57 @@ char* rocksdb_sst_file_metadata_get_largestkey(
   return CopyString(file_meta->rep->largestkey);
 }
 
-/* Transactions */
+rocksdb_import_column_family_options_t*
+rocksdb_import_column_family_options_create() {
+  return new rocksdb_import_column_family_options_t;
+}
+
+void rocksdb_import_column_family_options_set_move_files(
+    rocksdb_import_column_family_options_t* opt, unsigned char v) {
+  opt->rep.move_files = v;
+}
+
+void rocksdb_import_column_family_options_destroy(
+    rocksdb_import_column_family_options_t* metadata) {
+  delete metadata;
+}
+
+rocksdb_export_import_files_metadata_t*
+rocksdb_export_import_files_metadata_create() {
+  auto metadata = new rocksdb_export_import_files_metadata_t;
+  metadata->rep = new ExportImportFilesMetaData;
+  return metadata;
+}
+
+char* rocksdb_export_import_files_metadata_get_db_comparator_name(
+    rocksdb_export_import_files_metadata_t* metadata) {
+  return CopyString(metadata->rep->db_comparator_name);
+}
+
+void rocksdb_export_import_files_metadata_set_db_comparator_name(
+    rocksdb_export_import_files_metadata_t* metadata, const char* name) {
+  metadata->rep->db_comparator_name = std::string(name);
+}
+
+rocksdb_livefiles_t* rocksdb_export_import_files_metadata_get_files(
+    rocksdb_export_import_files_metadata_t* export_import_metadata) {
+  auto files = new rocksdb_livefiles_t;
+  files->rep = std::vector(export_import_metadata->rep->files);
+  return files;
+}
+
+void rocksdb_export_import_files_metadata_set_files(
+    rocksdb_export_import_files_metadata_t* metadata,
+    rocksdb_livefiles_t* files) {
+  metadata->rep->files.clear();
+  metadata->rep->files = std::vector(files->rep);
+}
+
+void rocksdb_export_import_files_metadata_destroy(
+    rocksdb_export_import_files_metadata_t* metadata) {
+  delete metadata->rep;
+  delete metadata;
+}
 
 rocksdb_transactiondb_options_t* rocksdb_transactiondb_options_create() {
   return new rocksdb_transactiondb_options_t;

--- a/db/c.cc
+++ b/db/c.cc
@@ -6056,7 +6056,8 @@ void rocksdb_export_import_files_metadata_set_files(
     rocksdb_export_import_files_metadata_t* metadata,
     rocksdb_livefiles_t* files) {
   metadata->rep->files.clear();
-  metadata->rep->files = std::vector(files->rep);
+  metadata->rep->files = std::move(files->rep);
+  delete files;
 }
 
 void rocksdb_export_import_files_metadata_destroy(

--- a/db/c.cc
+++ b/db/c.cc
@@ -5798,7 +5798,8 @@ rocksdb_livefile_t* rocksdb_livefile_create() {
   return new rocksdb_livefile_t;
 }
 
-void rocksdb_livefile_set_column_family_name(rocksdb_livefile_t* lf, const char* column_family_name) {
+void rocksdb_livefile_set_column_family_name(rocksdb_livefile_t* lf,
+                                             const char* column_family_name) {
   lf->rep.column_family_name = std::string(column_family_name);
 }
 
@@ -5810,36 +5811,45 @@ void rocksdb_livefile_set_name(rocksdb_livefile_t* lf, const char* name) {
   lf->rep.name = std::string(name);
 }
 
-void rocksdb_livefile_set_directory(rocksdb_livefile_t* lf, const char* directory) {
+void rocksdb_livefile_set_directory(rocksdb_livefile_t* lf,
+                                    const char* directory) {
   lf->rep.directory = std::string(directory);
-  lf->rep.db_path = std::string(directory); // deprecated but necessary
+  lf->rep.db_path = std::string(directory); // deprecated but still needed
 }
 
 void rocksdb_livefile_set_size(rocksdb_livefile_t* lf, size_t size) {
   lf->rep.size = size;
 }
 
-void rocksdb_livefile_set_smallest_key(rocksdb_livefile_t* lf, const char* smallest_key, size_t smallest_key_len) {
+void rocksdb_livefile_set_smallest_key(rocksdb_livefile_t* lf,
+                                       const char* smallest_key,
+                                       size_t smallest_key_len) {
   lf->rep.smallestkey = std::string(smallest_key, smallest_key_len);
 }
 
-void rocksdb_livefile_set_largest_key(rocksdb_livefile_t* lf, const char* largest_key, size_t largest_key_len) {
+void rocksdb_livefile_set_largest_key(rocksdb_livefile_t* lf,
+                                      const char* largest_key,
+                                      size_t largest_key_len) {
   lf->rep.largestkey = std::string(largest_key, largest_key_len);
 }
 
-void rocksdb_livefile_set_smallest_seqno(rocksdb_livefile_t* lf, uint64_t smallest_seqno) {
+void rocksdb_livefile_set_smallest_seqno(rocksdb_livefile_t* lf,
+                                         uint64_t smallest_seqno) {
   lf->rep.smallest_seqno = smallest_seqno;
 }
 
-void rocksdb_livefile_set_largest_seqno(rocksdb_livefile_t* lf, uint64_t largest_seqno) {
+void rocksdb_livefile_set_largest_seqno(rocksdb_livefile_t* lf,
+                                        uint64_t largest_seqno) {
   lf->rep.largest_seqno = largest_seqno;
 }
 
-void rocksdb_livefile_set_num_entries(rocksdb_livefile_t* lf, uint64_t num_entries) {
+void rocksdb_livefile_set_num_entries(rocksdb_livefile_t* lf,
+                                      uint64_t num_entries) {
   lf->rep.num_entries = num_entries;
 }
 
-void rocksdb_livefile_set_num_deletions(rocksdb_livefile_t* lf, uint64_t num_deletions) {
+void rocksdb_livefile_set_num_deletions(rocksdb_livefile_t* lf,
+                                        uint64_t num_deletions) {
   lf->rep.num_deletions = num_deletions;
 }
 
@@ -5847,7 +5857,8 @@ void rocksdb_livefile_destroy(rocksdb_livefile_t* lf) {
   delete lf;
 }
 
-void rocksdb_livefiles_add(rocksdb_livefiles_t* lf, rocksdb_livefile_t* livefile) {
+void rocksdb_livefiles_add(rocksdb_livefiles_t* lf,
+                           rocksdb_livefile_t* livefile) {
   lf->rep.push_back(std::move(livefile->rep));
   delete livefile;
 }

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -115,6 +115,11 @@ typedef struct rocksdb_livefiles_t rocksdb_livefiles_t;
 typedef struct rocksdb_column_family_handle_t rocksdb_column_family_handle_t;
 typedef struct rocksdb_column_family_metadata_t
     rocksdb_column_family_metadata_t;
+typedef struct rocksdb_live_file_metadata_t rocksdb_live_file_metadata_t;
+typedef struct rocksdb_import_column_family_options_t
+    rocksdb_import_column_family_options_t;
+typedef struct rocksdb_export_import_files_metadata_t
+    rocksdb_export_import_files_metadata_t;
 typedef struct rocksdb_level_metadata_t rocksdb_level_metadata_t;
 typedef struct rocksdb_sst_file_metadata_t rocksdb_sst_file_metadata_t;
 typedef struct rocksdb_envoptions_t rocksdb_envoptions_t;
@@ -366,6 +371,12 @@ extern ROCKSDB_LIBRARY_API void rocksdb_checkpoint_create(
     rocksdb_checkpoint_t* checkpoint, const char* checkpoint_dir,
     uint64_t log_size_for_flush, char** errptr);
 
+extern ROCKSDB_LIBRARY_API rocksdb_export_import_files_metadata_t*
+rocksdb_checkpoint_export_column_family(
+    rocksdb_checkpoint_t* checkpoint,
+    rocksdb_column_family_handle_t* column_family, const char* export_dir,
+    char** errptr);
+
 extern ROCKSDB_LIBRARY_API void rocksdb_checkpoint_object_destroy(
     rocksdb_checkpoint_t* checkpoint);
 
@@ -425,6 +436,13 @@ rocksdb_create_column_families(rocksdb_t* db,
 
 extern ROCKSDB_LIBRARY_API void rocksdb_create_column_families_destroy(
     rocksdb_column_family_handle_t** list);
+
+extern ROCKSDB_LIBRARY_API rocksdb_column_family_handle_t*
+rocksdb_create_column_family_with_import(
+    rocksdb_t* db, rocksdb_options_t* column_family_options,
+    const char* column_family_name,
+    rocksdb_import_column_family_options_t* import_options,
+    rocksdb_export_import_files_metadata_t* metadata, char** errptr);
 
 extern ROCKSDB_LIBRARY_API rocksdb_column_family_handle_t*
 rocksdb_create_column_family_with_ttl(
@@ -2443,11 +2461,22 @@ rocksdb_fifo_compaction_options_get_max_table_files_size(
 extern ROCKSDB_LIBRARY_API void rocksdb_fifo_compaction_options_destroy(
     rocksdb_fifo_compaction_options_t* fifo_opts);
 
+extern ROCKSDB_LIBRARY_API rocksdb_livefiles_t* rocksdb_livefiles_create();
+
+extern ROCKSDB_LIBRARY_API void rocksdb_livefiles_add(
+    rocksdb_livefiles_t* lf, const char* column_family_name, const char* name,
+    const char* directory, size_t size, int level, const char* start_key,
+    size_t start_key_len, const char* end_key, size_t end_key_len,
+    uint64_t smallest_seqno, uint64_t largest_seqno, uint64_t num_entries,
+    uint64_t num_deletions);
+
 extern ROCKSDB_LIBRARY_API int rocksdb_livefiles_count(
     const rocksdb_livefiles_t*);
 extern ROCKSDB_LIBRARY_API const char* rocksdb_livefiles_column_family_name(
     const rocksdb_livefiles_t*, int index);
 extern ROCKSDB_LIBRARY_API const char* rocksdb_livefiles_name(
+    const rocksdb_livefiles_t*, int index);
+extern ROCKSDB_LIBRARY_API const char* rocksdb_livefiles_directory(
     const rocksdb_livefiles_t*, int index);
 extern ROCKSDB_LIBRARY_API int rocksdb_livefiles_level(
     const rocksdb_livefiles_t*, int index);
@@ -2457,6 +2486,10 @@ extern ROCKSDB_LIBRARY_API const char* rocksdb_livefiles_smallestkey(
     const rocksdb_livefiles_t*, int index, size_t* size);
 extern ROCKSDB_LIBRARY_API const char* rocksdb_livefiles_largestkey(
     const rocksdb_livefiles_t*, int index, size_t* size);
+extern ROCKSDB_LIBRARY_API uint64_t rocksdb_livefiles_smallest_seqno(
+    const rocksdb_livefiles_t*, int index);
+extern ROCKSDB_LIBRARY_API uint64_t rocksdb_livefiles_largest_seqno(
+    const rocksdb_livefiles_t*, int index);
 extern ROCKSDB_LIBRARY_API uint64_t
 rocksdb_livefiles_entries(const rocksdb_livefiles_t*, int index);
 extern ROCKSDB_LIBRARY_API uint64_t
@@ -2483,6 +2516,37 @@ extern ROCKSDB_LIBRARY_API void rocksdb_delete_file_in_range_cf(
 
 extern ROCKSDB_LIBRARY_API rocksdb_column_family_metadata_t*
 rocksdb_get_column_family_metadata(rocksdb_t* db);
+
+extern ROCKSDB_LIBRARY_API rocksdb_import_column_family_options_t*
+rocksdb_import_column_family_options_create(void);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_import_column_family_options_set_move_files(
+    rocksdb_import_column_family_options_t*, unsigned char);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_import_column_family_options_destroy(rocksdb_import_column_family_options_t*);
+
+extern ROCKSDB_LIBRARY_API rocksdb_export_import_files_metadata_t*
+rocksdb_export_import_files_metadata_create(void);
+
+extern ROCKSDB_LIBRARY_API char*
+rocksdb_export_import_files_metadata_get_db_comparator_name(
+    rocksdb_export_import_files_metadata_t*);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_export_import_files_metadata_set_db_comparator_name(
+    rocksdb_export_import_files_metadata_t*, const char*);
+
+extern ROCKSDB_LIBRARY_API rocksdb_livefiles_t*
+rocksdb_export_import_files_metadata_get_files(
+    rocksdb_export_import_files_metadata_t*);
+
+extern ROCKSDB_LIBRARY_API void rocksdb_export_import_files_metadata_set_files(
+    rocksdb_export_import_files_metadata_t*, rocksdb_livefiles_t*);
+
+extern ROCKSDB_LIBRARY_API void rocksdb_export_import_files_metadata_destroy(
+    rocksdb_export_import_files_metadata_t*);
 
 /**
  * Returns the rocksdb_column_family_metadata_t of the specified

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -111,6 +111,7 @@ typedef struct rocksdb_writebatch_wi_t rocksdb_writebatch_wi_t;
 typedef struct rocksdb_writeoptions_t rocksdb_writeoptions_t;
 typedef struct rocksdb_universal_compaction_options_t
     rocksdb_universal_compaction_options_t;
+typedef struct rocksdb_livefile_t rocksdb_livefile_t;
 typedef struct rocksdb_livefiles_t rocksdb_livefiles_t;
 typedef struct rocksdb_column_family_handle_t rocksdb_column_family_handle_t;
 typedef struct rocksdb_column_family_metadata_t
@@ -2480,13 +2481,6 @@ extern ROCKSDB_LIBRARY_API void rocksdb_fifo_compaction_options_destroy(
 
 extern ROCKSDB_LIBRARY_API rocksdb_livefiles_t* rocksdb_livefiles_create();
 
-extern ROCKSDB_LIBRARY_API void rocksdb_livefiles_add(
-    rocksdb_livefiles_t* lf, const char* column_family_name, const char* name,
-    const char* directory, size_t size, int level, const char* start_key,
-    size_t start_key_len, const char* end_key, size_t end_key_len,
-    uint64_t smallest_seqno, uint64_t largest_seqno, uint64_t num_entries,
-    uint64_t num_deletions);
-
 extern ROCKSDB_LIBRARY_API int rocksdb_livefiles_count(
     const rocksdb_livefiles_t*);
 extern ROCKSDB_LIBRARY_API const char* rocksdb_livefiles_column_family_name(
@@ -2513,6 +2507,23 @@ extern ROCKSDB_LIBRARY_API uint64_t
 rocksdb_livefiles_deletions(const rocksdb_livefiles_t*, int index);
 extern ROCKSDB_LIBRARY_API void rocksdb_livefiles_destroy(
     const rocksdb_livefiles_t*);
+
+extern ROCKSDB_LIBRARY_API rocksdb_livefile_t* rocksdb_livefile_create();
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_column_family_name(rocksdb_livefile_t*, const char*);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_level(rocksdb_livefile_t*, int);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_name(rocksdb_livefile_t*, const char*);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_directory(rocksdb_livefile_t*, const char*);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_size(rocksdb_livefile_t*, size_t);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_smallest_key(rocksdb_livefile_t*, const char*, size_t);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_largest_key(rocksdb_livefile_t*, const char*, size_t);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_smallest_seqno(rocksdb_livefile_t*, uint64_t);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_largest_seqno(rocksdb_livefile_t*, uint64_t);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_num_entries(rocksdb_livefile_t*, uint64_t);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_num_deletions(rocksdb_livefile_t*, uint64_t);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_destroy(rocksdb_livefile_t*);
+
+// Takes ownership of the livefile being added.
+extern ROCKSDB_LIBRARY_API void rocksdb_livefiles_add(rocksdb_livefiles_t*, rocksdb_livefile_t*);
 
 /* Utility Helpers */
 

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -115,7 +115,6 @@ typedef struct rocksdb_livefiles_t rocksdb_livefiles_t;
 typedef struct rocksdb_column_family_handle_t rocksdb_column_family_handle_t;
 typedef struct rocksdb_column_family_metadata_t
     rocksdb_column_family_metadata_t;
-typedef struct rocksdb_live_file_metadata_t rocksdb_live_file_metadata_t;
 typedef struct rocksdb_import_column_family_options_t
     rocksdb_import_column_family_options_t;
 typedef struct rocksdb_export_import_files_metadata_t

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -2509,21 +2509,33 @@ extern ROCKSDB_LIBRARY_API void rocksdb_livefiles_destroy(
     const rocksdb_livefiles_t*);
 
 extern ROCKSDB_LIBRARY_API rocksdb_livefile_t* rocksdb_livefile_create();
-extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_column_family_name(rocksdb_livefile_t*, const char*);
-extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_level(rocksdb_livefile_t*, int);
-extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_name(rocksdb_livefile_t*, const char*);
-extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_directory(rocksdb_livefile_t*, const char*);
-extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_size(rocksdb_livefile_t*, size_t);
-extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_smallest_key(rocksdb_livefile_t*, const char*, size_t);
-extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_largest_key(rocksdb_livefile_t*, const char*, size_t);
-extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_smallest_seqno(rocksdb_livefile_t*, uint64_t);
-extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_largest_seqno(rocksdb_livefile_t*, uint64_t);
-extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_num_entries(rocksdb_livefile_t*, uint64_t);
-extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_num_deletions(rocksdb_livefile_t*, uint64_t);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_column_family_name(
+    rocksdb_livefile_t*, const char*);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_level(
+    rocksdb_livefile_t*, int);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_name(
+    rocksdb_livefile_t*, const char*);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_directory(
+rocksdb_livefile_t*, const char*);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_size(
+    rocksdb_livefile_t*, size_t);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_smallest_key(
+    rocksdb_livefile_t*, const char*, size_t);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_largest_key(
+    rocksdb_livefile_t*, const char*, size_t);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_smallest_seqno(
+    rocksdb_livefile_t*, uint64_t);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_largest_seqno(
+    rocksdb_livefile_t*, uint64_t);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_num_entries(
+    rocksdb_livefile_t*, uint64_t);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_num_deletions(
+    rocksdb_livefile_t*, uint64_t);
 extern ROCKSDB_LIBRARY_API void rocksdb_livefile_destroy(rocksdb_livefile_t*);
 
 // Takes ownership of the livefile being added.
-extern ROCKSDB_LIBRARY_API void rocksdb_livefiles_add(rocksdb_livefiles_t*, rocksdb_livefile_t*);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefiles_add(rocksdb_livefiles_t*,
+    rocksdb_livefile_t*);
 
 /* Utility Helpers */
 

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -2582,6 +2582,7 @@ extern ROCKSDB_LIBRARY_API rocksdb_livefiles_t*
 rocksdb_export_import_files_metadata_get_files(
     rocksdb_export_import_files_metadata_t*);
 
+// Takes ownership of the rocksdb_livefiles_t being added.
 extern ROCKSDB_LIBRARY_API void rocksdb_export_import_files_metadata_set_files(
     rocksdb_export_import_files_metadata_t*, rocksdb_livefiles_t*);
 


### PR DESCRIPTION
This change adds the ability to export and import column families via the C API.
 
The two key APIs introduced are:

- `rocksdb_checkpoint_export_column_family` (wraps `Checkpoint::ExportColumnFamily`)
- `rocksdb_create_column_family_with_import` (wraps `DB::CreateColumnFamilyWithImport`)

plus supporting functions for allocation/deallocation and data structure mapping.