### PR TITLE
Fix pinnable slice deallocation in writebatch_wi test

### DIFF
--- a/db/c_test.c
+++ b/db/c_test.c
@@ -1243,18 +1243,24 @@ int main(int argc, char** argv) {
     CheckValue(err, NULL, &value, size);
     value = rocksdb_writebatch_wi_get_from_batch_and_db(wbi, db, roptions,
                                                         "foo", 3, &size, &err);
+    const char* pvalue;
     CheckValue(err, "hello", &value, size);
     p = rocksdb_writebatch_wi_get_pinned_from_batch_and_db(wbi, db, roptions,
                                                            "foo", 3, &err);
-    value = rocksdb_pinnableslice_value(p, &size);
-    CheckValue(err, "hello", &value, size);
+    pvalue = rocksdb_pinnableslice_value(p, &size);
+    CheckEqual("hello", pvalue, size);
+    rocksdb_pinnableslice_destroy(p);
+
     value = rocksdb_writebatch_wi_get_from_batch_and_db(wbi, db, roptions,
                                                         "box", 3, &size, &err);
     CheckValue(err, "c", &value, size);
+
     p = rocksdb_writebatch_wi_get_pinned_from_batch_and_db(wbi, db, roptions,
                                                            "box", 3, &err);
-    value = rocksdb_pinnableslice_value(p, &size);
-    CheckValue(err, "c", &value, size);
+    pvalue = rocksdb_pinnableslice_value(p, &size);
+    CheckEqual("c", pvalue, size);
+    rocksdb_pinnableslice_destroy(p);
+
     rocksdb_write_writebatch_wi(db, woptions, wbi, &err);
     CheckNoError(err);
     CheckGet(db, roptions, "foo", "hello");


### PR DESCRIPTION
Fix incorrect free in `c_test` "writebatch_wi" introduced by https://github.com/restatedev/rocksdb/pull/2. The returned pinnable slice should be deallocated using `rocksdb_pinnableslice_destroy`, and not with `free` (which is what `CheckValue` does internally). This change also fixes the type error reported by the compiler.

Before:

```
% make c_test
...
db/c_test.c: In function ‘main’:
db/c_test.c:1249:11: error: assignment discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
 1249 |     value = rocksdb_pinnableslice_value(p, &size);
      |           ^
db/c_test.c:1256:11: error: assignment discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
 1256 |     value = rocksdb_pinnableslice_value(p, &size);
      |           ^
```

If you ignore the warnings and compile it anyway, the program crashes due to the incorrect deallocation:

```
root@i-0fac6e10d30876656:/rust-rocksdb/librocksdb-sys/rocksdb# ./c_test
=== Test create_objects
=== Test destroy
=== Test open_error
=== Test open
=== Test put
=== Test backup_and_restore
=== Test checkpoint
=== Test checkpoint_db_id_in_manifest
=== Test compactall
=== Test compactrange
=== Test compactallopt
=== Test compactrangeopt
=== Test cache_usage
=== Test addfile
=== Test writebatch
=== Test writebatch_vectors
=== Test writebatch_savepoint
=== Test writebatch_rep
=== Test writebatch_wi
free(): invalid pointer
Aborted (core dumped)
```

After:

```
root@i-0fac6e10d30876656:/rust-rocksdb/librocksdb-sys/rocksdb# ./c_test
=== Test create_objects
=== Test destroy
=== Test open_error
=== Test open
=== Test put
=== Test backup_and_restore
=== Test checkpoint
=== Test checkpoint_db_id_in_manifest
=== Test compactall
=== Test compactrange
=== Test compactallopt
=== Test compactrangeopt
=== Test cache_usage
=== Test addfile
=== Test writebatch
=== Test writebatch_vectors
=== Test writebatch_savepoint
=== Test writebatch_rep
=== Test writebatch_wi
=== Test writebatch_wi_vectors
=== Test writebatch_wi_savepoint
=== Test iter
=== Test wbwi_iter
=== Test multiget
=== Test pin_get
=== Test approximate_sizes
=== Test property
=== Test snapshot
=== Test snapshot_with_memtable_inplace_update
=== Test repair
=== Test filter
=== Test compaction_filter
=== Test compaction_filter_factory
=== Test merge_operator
=== Test columnfamilies
=== Test prefix
=== Test approximate_memory_usage
=== Test cuckoo_options
=== Test options
=== Test read_options
=== Test write_options
=== Test compact_options
=== Test flush_options
=== Test cache_options
=== Test jemalloc_nodump_allocator
=== Test stderr_logger
=== Test env
=== Test universal_compaction_options
=== Test fifo_compaction_options
=== Test backup_engine_option
=== Test compression_options
=== Test iterate_upper_bound
=== Test transactions
=== Test two-phase commit
=== Test transactions_multi_get_for_update
=== Test optimistic_transactions
=== Test memtable_reps
=== Test open_as_secondary
=== Test open_db_paths
=== Test filter_with_prefix_seek
=== Test statistics
=== Test wait_for_compact_options
=== Test wait_for_compact
=== Test write_buffer_manager
=== Test cancel_all_background_work
=== Test cleanup
PASS
```