### PR TITLE
Return C-style string from metadata db comparator getter

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -6037,7 +6037,7 @@ rocksdb_export_import_files_metadata_create() {
 
 char* rocksdb_export_import_files_metadata_get_db_comparator_name(
     rocksdb_export_import_files_metadata_t* metadata) {
-  return CopyString(metadata->rep->db_comparator_name);
+  return strdup(metadata->rep->db_comparator_name.c_str());
 }
 
 void rocksdb_export_import_files_metadata_set_db_comparator_name(

--- a/db/c.cc
+++ b/db/c.cc
@@ -917,7 +917,7 @@ rocksdb_export_import_files_metadata_t* rocksdb_checkpoint_export_column_family(
     rocksdb_checkpoint_t* checkpoint,
     rocksdb_column_family_handle_t* column_family, const char* export_dir,
     char** errptr) {
-  ExportImportFilesMetaData* metadata;
+  ExportImportFilesMetaData* metadata = nullptr;
   if (SaveError(errptr,
                 checkpoint->rep->ExportColumnFamily(
                     column_family->rep, std::string(export_dir), &metadata))) {
@@ -1179,6 +1179,7 @@ rocksdb_column_family_handle_t* rocksdb_create_column_family_with_import(
     rocksdb_export_import_files_metadata_t* export_import_files_metadata,
     char** errptr) {
   rocksdb_column_family_handle_t* handle = new rocksdb_column_family_handle_t;
+  handle->rep = nullptr;
   SaveError(errptr, db->rep->CreateColumnFamilyWithImport(
                         ColumnFamilyOptions(column_family_options->rep),
                         std::string(column_family_name), import_options->rep,

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -1019,6 +1019,94 @@ int main(int argc, char** argv) {
     rocksdb_options_set_error_if_exists(options, 1);
   }
 
+  StartPhase("checkpoint_export_column_family");
+  {
+    static char cf_export_path[200];
+    static char db_import_path[200];
+
+    snprintf(cf_export_path, sizeof(cf_export_path),
+             "%s/rocksdb_c_test-%d-cf_export-%d", GetTempDir(),
+             ((int)geteuid()), ((int)getpid()));
+    snprintf(db_import_path, sizeof(dbname),
+             "%s/rocksdb_c_test-%d-db_cf_import-%d", GetTempDir(),
+             ((int)geteuid()), ((int)getpid()));
+
+    // Create column families
+    rocksdb_options_t* db_options = rocksdb_options_create();
+    rocksdb_column_family_handle_t* cf_export =
+        rocksdb_create_column_family(db, db_options, "cf_export", &err);
+    CheckNoError(err);
+
+    // Put data into column families
+    rocksdb_writeoptions_t* write_options = rocksdb_writeoptions_create();
+    rocksdb_put_cf(db, write_options, cf_export, "k1", 2, "v1", 2, &err);
+    CheckNoError(err);
+    rocksdb_put_cf(db, write_options, cf_export, "k2", 2, "v2", 2, &err);
+    CheckNoError(err);
+
+    // Create checkpoint object
+    rocksdb_checkpoint_t* checkpoint =
+        rocksdb_checkpoint_object_create(db, &err);
+    CheckNoError(err);
+
+    // Export column family
+    rocksdb_export_import_files_metadata_t* export_metadata =
+        rocksdb_checkpoint_export_column_family(checkpoint, cf_export,
+                                                cf_export_path, &err);
+    CheckNoError(err);
+    const char* comparator_name =
+        rocksdb_export_import_files_metadata_get_db_comparator_name(
+            export_metadata);
+    CheckEqual("leveldb.BytewiseComparator", comparator_name, 26);
+    rocksdb_free((void*)comparator_name);
+
+    rocksdb_checkpoint_object_destroy(checkpoint);
+    rocksdb_drop_column_family(db, cf_export, &err);
+    CheckNoError(err);
+    rocksdb_column_family_handle_destroy(cf_export);
+
+    // Open a new database into which we will import the exported CF into
+    rocksdb_options_set_create_if_missing(db_options, 1);
+    rocksdb_options_set_error_if_exists(db_options, 1);
+    rocksdb_t* db_import = rocksdb_open(db_options, db_import_path, &err);
+    CheckNoError(err);
+
+    // Import column family
+    rocksdb_import_column_family_options_t* import_options =
+        rocksdb_import_column_family_options_create();
+    rocksdb_column_family_handle_t* cf_import =
+        rocksdb_create_column_family_with_import(db_import, db_options,
+                                                 "cf_import", import_options,
+                                                 export_metadata, &err);
+    CheckNoError(err);
+    rocksdb_import_column_family_options_destroy(import_options);
+    rocksdb_export_import_files_metadata_destroy(export_metadata);
+
+    // Verify imported data
+    rocksdb_readoptions_t* read_options = rocksdb_readoptions_create();
+    size_t val_len;
+    char* val = rocksdb_get_cf(db_import, read_options, cf_import, "k1", 2,
+                               &val_len, &err);
+    CheckNoError(err);
+    CheckEqual("v1", val, val_len);
+    free(val);
+
+    val = rocksdb_get_cf(db_import, read_options, cf_import, "k2", 2, &val_len,
+                         &err);
+    CheckNoError(err);
+    CheckEqual("v2", val, val_len);
+    free(val);
+
+    // Clean up
+    rocksdb_column_family_handle_destroy(cf_import);
+    cf_import = NULL;
+    rocksdb_close(db_import);
+    rocksdb_destroy_db(db_options, db_import_path, &err);
+    CheckNoError(err);
+    rocksdb_options_destroy(db_options);
+    db_options = NULL;
+  }
+
   StartPhase("compactall");
   rocksdb_compact_range(db, NULL, 0, NULL, 0);
   CheckGet(db, roptions, "foo", "hello");

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -2479,7 +2479,7 @@ rocksdb_fifo_compaction_options_get_max_table_files_size(
 extern ROCKSDB_LIBRARY_API void rocksdb_fifo_compaction_options_destroy(
     rocksdb_fifo_compaction_options_t* fifo_opts);
 
-extern ROCKSDB_LIBRARY_API rocksdb_livefiles_t* rocksdb_livefiles_create();
+extern ROCKSDB_LIBRARY_API rocksdb_livefiles_t* rocksdb_livefiles_create(void);
 
 extern ROCKSDB_LIBRARY_API int rocksdb_livefiles_count(
     const rocksdb_livefiles_t*);
@@ -2497,10 +2497,10 @@ extern ROCKSDB_LIBRARY_API const char* rocksdb_livefiles_smallestkey(
     const rocksdb_livefiles_t*, int index, size_t* size);
 extern ROCKSDB_LIBRARY_API const char* rocksdb_livefiles_largestkey(
     const rocksdb_livefiles_t*, int index, size_t* size);
-extern ROCKSDB_LIBRARY_API uint64_t rocksdb_livefiles_smallest_seqno(
-    const rocksdb_livefiles_t*, int index);
-extern ROCKSDB_LIBRARY_API uint64_t rocksdb_livefiles_largest_seqno(
-    const rocksdb_livefiles_t*, int index);
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_livefiles_smallest_seqno(const rocksdb_livefiles_t*, int index);
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_livefiles_largest_seqno(const rocksdb_livefiles_t*, int index);
 extern ROCKSDB_LIBRARY_API uint64_t
 rocksdb_livefiles_entries(const rocksdb_livefiles_t*, int index);
 extern ROCKSDB_LIBRARY_API uint64_t
@@ -2508,17 +2508,17 @@ rocksdb_livefiles_deletions(const rocksdb_livefiles_t*, int index);
 extern ROCKSDB_LIBRARY_API void rocksdb_livefiles_destroy(
     const rocksdb_livefiles_t*);
 
-extern ROCKSDB_LIBRARY_API rocksdb_livefile_t* rocksdb_livefile_create();
+extern ROCKSDB_LIBRARY_API rocksdb_livefile_t* rocksdb_livefile_create(void);
 extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_column_family_name(
     rocksdb_livefile_t*, const char*);
-extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_level(
-    rocksdb_livefile_t*, int);
-extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_name(
-    rocksdb_livefile_t*, const char*);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_level(rocksdb_livefile_t*,
+                                                           int);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_name(rocksdb_livefile_t*,
+                                                          const char*);
 extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_directory(
-rocksdb_livefile_t*, const char*);
-extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_size(
-    rocksdb_livefile_t*, size_t);
+    rocksdb_livefile_t*, const char*);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_size(rocksdb_livefile_t*,
+                                                          size_t);
 extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_smallest_key(
     rocksdb_livefile_t*, const char*, size_t);
 extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_largest_key(
@@ -2535,7 +2535,7 @@ extern ROCKSDB_LIBRARY_API void rocksdb_livefile_destroy(rocksdb_livefile_t*);
 
 // Takes ownership of the livefile being added.
 extern ROCKSDB_LIBRARY_API void rocksdb_livefiles_add(rocksdb_livefiles_t*,
-    rocksdb_livefile_t*);
+                                                      rocksdb_livefile_t*);
 
 /* Utility Helpers */
 
@@ -2564,12 +2564,13 @@ extern ROCKSDB_LIBRARY_API void
 rocksdb_import_column_family_options_set_move_files(
     rocksdb_import_column_family_options_t*, unsigned char);
 
-extern ROCKSDB_LIBRARY_API void
-rocksdb_import_column_family_options_destroy(rocksdb_import_column_family_options_t*);
+extern ROCKSDB_LIBRARY_API void rocksdb_import_column_family_options_destroy(
+    rocksdb_import_column_family_options_t*);
 
 extern ROCKSDB_LIBRARY_API rocksdb_export_import_files_metadata_t*
 rocksdb_export_import_files_metadata_create(void);
 
+// Returns a copy of C-allocated NUL-terminated string.
 extern ROCKSDB_LIBRARY_API char*
 rocksdb_export_import_files_metadata_get_db_comparator_name(
     rocksdb_export_import_files_metadata_t*);


### PR DESCRIPTION
Update the C FFI function rocksdb_export_import_files_metadata_get_db_comparator_name function to return a regular C-style string to align with similar usage elsewhere, e.g. returning column family names.

This PR also adds a C FFI test for the new column family export/import APIs introduced in https://github.com/restatedev/rocksdb/pull/1.

Finally, this PR updates some FFI APIs which previously did not initialize newly-allocated empty pointer holders to null. This resulted in failing runtime assertions on Linux which are now gone.