### PR TITLE
Expose EventListener / OnFlushCompleted event

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -24,6 +24,7 @@
 #include "rocksdb/experimental.h"
 #include "rocksdb/filter_policy.h"
 #include "rocksdb/iterator.h"
+#include "rocksdb/listener.h"
 #include "rocksdb/memtablerep.h"
 #include "rocksdb/merge_operator.h"
 #include "rocksdb/options.h"
@@ -76,9 +77,11 @@ using ROCKSDB_NAMESPACE::DBOptions;
 using ROCKSDB_NAMESPACE::DbPath;
 using ROCKSDB_NAMESPACE::Env;
 using ROCKSDB_NAMESPACE::EnvOptions;
+using ROCKSDB_NAMESPACE::EventListener;
 using ROCKSDB_NAMESPACE::ExportImportFilesMetaData;
 using ROCKSDB_NAMESPACE::FileLock;
 using ROCKSDB_NAMESPACE::FilterPolicy;
+using ROCKSDB_NAMESPACE::FlushJobInfo;
 using ROCKSDB_NAMESPACE::FlushOptions;
 using ROCKSDB_NAMESPACE::HistogramData;
 using ROCKSDB_NAMESPACE::HyperClockCacheOptions;
@@ -416,6 +419,84 @@ struct rocksdb_filterpolicy_t : public FilterPolicy {
 
   const char* Name() const override { return (*name_)(state_); }
 };
+
+/* Event Listener */
+
+struct rocksdb_flushjobinfo_t {
+  const FlushJobInfo* rep;
+};
+
+struct rocksdb_event_listener_t : public EventListener {
+  void* state_;
+  void (*destructor_)(void*);
+  void (*on_flush_completed_)(void*, const rocksdb_flushjobinfo_t* info);
+
+  rocksdb_event_listener_t(void* state, void (*destructor)(void*))
+      : EventListener() {
+    state_ = state;
+    destructor_ = destructor;
+    on_flush_completed_ = nullptr;
+  }
+
+  ~rocksdb_event_listener_t() override {
+    if (destructor_ != nullptr) {
+      (*destructor_)(state_);
+    }
+  }
+
+  void OnFlushCompleted(DB*, const FlushJobInfo& flush_job_info) override {
+    if (on_flush_completed_ != nullptr) {
+      rocksdb_flushjobinfo_t info;
+      info.rep = &flush_job_info;
+      (*on_flush_completed_)(state_, &info);
+    }
+  }
+};
+
+rocksdb_event_listener_t* rocksdb_event_listener_create(
+    void* state, void (*destructor)(void*)) {
+  return new rocksdb_event_listener_t(state, destructor);
+}
+
+void rocksdb_options_add_event_listener(
+    rocksdb_options_t* options, rocksdb_event_listener_t* event_listener) {
+  options->rep.listeners.emplace_back(event_listener);
+}
+
+void rocksdb_event_listener_destroy(rocksdb_event_listener_t* listener) {
+  delete listener;
+}
+
+void rocksdb_event_listener_set_on_flush_completed(
+    rocksdb_event_listener_t* t,
+    void (*on_flush_completed)(void*, const rocksdb_flushjobinfo_t*)) {
+  t->on_flush_completed_ = on_flush_completed;
+}
+
+const char* rocksdb_flushjobinfo_cf_name(const rocksdb_flushjobinfo_t* info) {
+  return info->rep->cf_name.c_str();
+}
+
+const char* rocksdb_flushjobinfo_file_path(const rocksdb_flushjobinfo_t* info) {
+  return info->rep->file_path.c_str();
+}
+
+uint64_t rocksdb_flushjobinfo_smallest_seqno(
+    const rocksdb_flushjobinfo_t* info) {
+  return info->rep->smallest_seqno;
+}
+
+uint64_t rocksdb_flushjobinfo_largest_seqno(
+    const rocksdb_flushjobinfo_t* info) {
+  return info->rep->largest_seqno;
+}
+
+rocksdb_flushreason_t rocksdb_flushjobinfo_flushreason(
+    const rocksdb_flushjobinfo_t* info) {
+  return static_cast<rocksdb_flushreason_t>(info->rep->flush_reason);
+}
+
+/* Merge Operator */
 
 struct rocksdb_mergeoperator_t : public MergeOperator {
   void* state_;

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -85,6 +85,7 @@ typedef struct rocksdb_compactionfiltercontext_t
 typedef struct rocksdb_compactionfilterfactory_t
     rocksdb_compactionfilterfactory_t;
 typedef struct rocksdb_comparator_t rocksdb_comparator_t;
+typedef struct rocksdb_event_listener_t rocksdb_event_listener_t;
 typedef struct rocksdb_dbpath_t rocksdb_dbpath_t;
 typedef struct rocksdb_env_t rocksdb_env_t;
 typedef struct rocksdb_fifo_compaction_options_t
@@ -1221,6 +1222,43 @@ extern ROCKSDB_LIBRARY_API void rocksdb_options_set_comparator(
     rocksdb_options_t*, rocksdb_comparator_t*);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_merge_operator(
     rocksdb_options_t*, rocksdb_mergeoperator_t*);
+
+/* Event Listener */
+
+typedef struct rocksdb_flushjobinfo_t rocksdb_flushjobinfo_t;
+typedef int rocksdb_flushreason_t;
+
+extern ROCKSDB_LIBRARY_API rocksdb_event_listener_t*
+rocksdb_event_listener_create(void*, void (*destructor_)(void*));
+
+// Takes ownership of the provided rocksdb_event_listener_t
+extern ROCKSDB_LIBRARY_API void rocksdb_options_add_event_listener(
+    rocksdb_options_t* options, rocksdb_event_listener_t* event_listener);
+
+extern ROCKSDB_LIBRARY_API void rocksdb_event_listener_destroy(
+    rocksdb_event_listener_t*);
+
+extern ROCKSDB_LIBRARY_API void rocksdb_event_listener_set_on_flush_completed(
+    rocksdb_event_listener_t*,
+    void (*on_flush_completed)(void*, const rocksdb_flushjobinfo_t*));
+
+extern ROCKSDB_LIBRARY_API const char* rocksdb_flushjobinfo_cf_name(
+    const rocksdb_flushjobinfo_t*);
+
+extern ROCKSDB_LIBRARY_API const char* rocksdb_flushjobinfo_file_path(
+    const rocksdb_flushjobinfo_t*);
+
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_flushjobinfo_smallest_seqno(const rocksdb_flushjobinfo_t*);
+
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_flushjobinfo_largest_seqno(const rocksdb_flushjobinfo_t*);
+
+extern ROCKSDB_LIBRARY_API rocksdb_flushreason_t
+rocksdb_flushjobinfo_flushreason(const rocksdb_flushjobinfo_t*);
+
+/* Merge Operator */
+
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_uint64add_merge_operator(
     rocksdb_options_t*);
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_compression_per_level(


### PR DESCRIPTION
This PR adds the ability to register event listeners in RocksDB's C API, specifically for the OnFlushCompleted event. It creates the necessary data structures and functions to:

- Create and destroy event listeners
- Add event listeners to RocksDB options
- Access information provided by the flush event through a C API

Rust counterpart: https://github.com/restatedev/rust-rocksdb/pull/8