### PR TITLE
Add FFI TablePropertiesCollector support

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -11,6 +11,7 @@
 
 #include <cstdlib>
 #include <map>
+#include <memory>
 #include <unordered_set>
 #include <vector>
 
@@ -34,6 +35,7 @@
 #include "rocksdb/statistics.h"
 #include "rocksdb/status.h"
 #include "rocksdb/table.h"
+#include "rocksdb/table_properties.h"
 #include "rocksdb/universal_compaction.h"
 #include "rocksdb/utilities/backup_engine.h"
 #include "rocksdb/utilities/checkpoint.h"
@@ -75,6 +77,7 @@ using ROCKSDB_NAMESPACE::CuckooTableOptions;
 using ROCKSDB_NAMESPACE::DB;
 using ROCKSDB_NAMESPACE::DBOptions;
 using ROCKSDB_NAMESPACE::DbPath;
+using ROCKSDB_NAMESPACE::EntryType;
 using ROCKSDB_NAMESPACE::Env;
 using ROCKSDB_NAMESPACE::EnvOptions;
 using ROCKSDB_NAMESPACE::EventListener;
@@ -113,6 +116,7 @@ using ROCKSDB_NAMESPACE::Range;
 using ROCKSDB_NAMESPACE::RateLimiter;
 using ROCKSDB_NAMESPACE::ReadOptions;
 using ROCKSDB_NAMESPACE::RestoreOptions;
+using ROCKSDB_NAMESPACE::SequenceNumber;
 using ROCKSDB_NAMESPACE::SequentialFile;
 using ROCKSDB_NAMESPACE::Slice;
 using ROCKSDB_NAMESPACE::SliceParts;
@@ -122,12 +126,15 @@ using ROCKSDB_NAMESPACE::SstFileMetaData;
 using ROCKSDB_NAMESPACE::SstFileWriter;
 using ROCKSDB_NAMESPACE::Status;
 using ROCKSDB_NAMESPACE::StderrLogger;
+using ROCKSDB_NAMESPACE::TableProperties;
+using ROCKSDB_NAMESPACE::TablePropertiesCollector;
 using ROCKSDB_NAMESPACE::TablePropertiesCollectorFactory;
 using ROCKSDB_NAMESPACE::Transaction;
 using ROCKSDB_NAMESPACE::TransactionDB;
 using ROCKSDB_NAMESPACE::TransactionDBOptions;
 using ROCKSDB_NAMESPACE::TransactionLogIterator;
 using ROCKSDB_NAMESPACE::TransactionOptions;
+using ROCKSDB_NAMESPACE::UserCollectedProperties;
 using ROCKSDB_NAMESPACE::WaitForCompactOptions;
 using ROCKSDB_NAMESPACE::WALRecoveryMode;
 using ROCKSDB_NAMESPACE::WritableFile;
@@ -344,6 +351,174 @@ struct rocksdb_compactionfilter_t : public CompactionFilter {
   bool IgnoreSnapshots() const override { return ignore_snapshots_; }
 };
 
+/* Table Properties */
+
+struct rocksdb_table_properties_t {
+  const TableProperties* rep;
+};
+
+struct rocksdb_table_properties_collector_factory_context_t {
+  TablePropertiesCollectorFactory::Context* rep;
+};
+
+struct rocksdb_user_collected_properties_t {
+  UserCollectedProperties* rep;
+};
+
+struct rocksdb_table_properties_collector_t : public TablePropertiesCollector {
+  void* state_;
+  void (*destructor_)(void*);
+  bool (*add_user_key_)(void*, const char* key, size_t key_len,
+                        const char* value, size_t value_len, int entry_type,
+                        uint64_t sequence_number, uint64_t file_size);
+  void (*block_add_)(void*, uint64_t, uint64_t, uint64_t);
+  bool (*finish_)(void*, rocksdb_user_collected_properties_t* properties);
+  void (*get_readable_properties_)(
+      void*, rocksdb_user_collected_properties_t* properties);
+  const char* (*name_)(void*);
+
+  rocksdb_table_properties_collector_t(
+      void* state, void (*destructor)(void*),
+      bool (*add_user_key)(void*, const char* key, size_t key_len,
+                           const char* value, size_t value_len, int entry_type,
+                           uint64_t sequence_number, uint64_t file_size),
+      void (*block_add)(void*, uint64_t, uint64_t, uint64_t),
+      bool (*finish)(void*, rocksdb_user_collected_properties_t* properties),
+      void (*get_readable_properties)(
+          void*, rocksdb_user_collected_properties_t* properties),
+      const char* (*name)(void*)) {
+    state_ = state;
+    destructor_ = destructor;
+    add_user_key_ = add_user_key;
+    block_add_ = block_add;
+    finish_ = finish;
+    get_readable_properties_ = get_readable_properties;
+    name_ = name;
+  }
+
+  ~rocksdb_table_properties_collector_t() override { (*destructor_)(state_); }
+
+  Status AddUserKey(const Slice& key, const Slice& value, EntryType entry_type,
+                    SequenceNumber seq, uint64_t file_size) override {
+    bool result = (*add_user_key_)(state_, key.data(), key.size(), value.data(),
+                                   value.size(), entry_type, seq, file_size);
+    if (result) {
+      return Status::OK();
+    } else {
+      return Status::Aborted();
+    }
+  }
+
+  void BlockAdd(uint64_t block_uncomp_bytes,
+                uint64_t block_compressed_bytes_fast,
+                uint64_t block_compressed_bytes_slow) override {
+    if (block_add_ != nullptr) {
+      (*block_add_)(state_, block_uncomp_bytes, block_compressed_bytes_fast,
+                    block_compressed_bytes_slow);
+    }
+  }
+
+  Status Finish(UserCollectedProperties* properties) override {
+    rocksdb_user_collected_properties_t user_collected_properties;
+    user_collected_properties.rep = properties;
+    bool result = (*finish_)(state_, &user_collected_properties);
+    if (result) {
+      return Status::OK();
+    } else {
+      return Status::Aborted();
+    }
+  }
+
+  UserCollectedProperties GetReadableProperties() const override {
+    UserCollectedProperties properties;
+    rocksdb_user_collected_properties_t user_collected_properties;
+    user_collected_properties.rep = &properties;
+    (*get_readable_properties_)(state_, &user_collected_properties);
+    return properties;
+  }
+
+  const char* Name() const override { return (*name_)(state_); }
+};
+
+struct rocksdb_table_properties_collector_factory_t
+    : public TablePropertiesCollectorFactory {
+  void* state_;
+  void (*destructor_)(void*);
+  rocksdb_table_properties_collector_t* (*create_table_properties_collector_)(
+      void*, rocksdb_table_properties_collector_context_t*);
+  const char* (*name_)(void*);
+
+  rocksdb_table_properties_collector_factory_t(
+      void* state, void (*destructor)(void*),
+      rocksdb_table_properties_collector_t* (
+          *create_table_properties_collector)(
+          void*, rocksdb_table_properties_collector_context_t*),
+      const char* (*name)(void*)) {
+    this->state_ = state;
+    this->destructor_ = destructor;
+    this->create_table_properties_collector_ =
+        create_table_properties_collector;
+    this->name_ = name;
+  }
+
+  ~rocksdb_table_properties_collector_factory_t() override {
+    (*destructor_)(state_);
+  }
+
+  TablePropertiesCollector* CreateTablePropertiesCollector(
+      TablePropertiesCollectorFactory::Context context) override {
+    rocksdb_table_properties_collector_context_t cb_context;
+    cb_context.rep = &context;
+    return (*create_table_properties_collector_)(state_, &cb_context);
+  }
+
+  const char* Name() const override { return (*name_)(state_); }
+};
+
+uint32_t rocksdb_table_properties_collector_context_get_column_family_id(
+    rocksdb_table_properties_collector_context_t* context) {
+  return context->rep->column_family_id;
+}
+
+int rocksdb_table_properties_collector_context_get_level_at_creation(
+    rocksdb_table_properties_collector_context_t* context) {
+  return context->rep->level_at_creation;
+}
+
+int rocksdb_table_properties_collector_context_get_num_levels(
+    rocksdb_table_properties_collector_context_t* context) {
+  return context->rep->num_levels;
+}
+
+uint64_t
+rocksdb_table_properties_collector_context_get_last_level_inclusive_max_seqno_threshold(
+    rocksdb_table_properties_collector_context_t* context) {
+  return context->rep->last_level_inclusive_max_seqno_threshold;
+}
+
+const char* rocksdb_table_properties_get_user_collected_property(
+    const rocksdb_table_properties_t* table_properties, const char* key) {
+  auto properties = table_properties->rep->user_collected_properties;
+  auto it = properties.find(std::string(key));
+  if (it != properties.end()) {
+    return strdup(it->second.c_str());
+  }
+  return nullptr;
+}
+
+void rocksdb_table_properties_destroy(
+    const rocksdb_table_properties_t* table_properties) {
+  delete table_properties;
+}
+
+void rocksdb_user_collected_properties_insert(
+    rocksdb_user_collected_properties_t* properties, const char* key,
+    const char* value) {
+  properties->rep->emplace(std::string(key), std::string(value));
+}
+
+/* Compaction Filter Factory */
+
 struct rocksdb_compactionfilterfactory_t : public CompactionFilterFactory {
   void* state_;
   void (*destructor_)(void*);
@@ -494,6 +669,13 @@ uint64_t rocksdb_flushjobinfo_largest_seqno(
 rocksdb_flushreason_t rocksdb_flushjobinfo_flushreason(
     const rocksdb_flushjobinfo_t* info) {
   return static_cast<rocksdb_flushreason_t>(info->rep->flush_reason);
+}
+
+const rocksdb_table_properties_t* rocksdb_flushjobinfo_table_properties(
+    const rocksdb_flushjobinfo_t* info) {
+  auto table_properties = new rocksdb_table_properties_t;
+  table_properties->rep = &info->rep->table_properties;
+  return table_properties;
 }
 
 /* Merge Operator */
@@ -3237,6 +3419,31 @@ void rocksdb_options_set_merge_operator(
   opt->rep.merge_operator = std::shared_ptr<MergeOperator>(merge_operator);
 }
 
+rocksdb_table_properties_collector_t* rocksdb_table_properties_collector_create(
+    void* state, void (*destructor)(void* state),
+    bool (*add_user_key)(void*, const char* key, size_t key_len,
+                         const char* value, size_t value_len, int entry_type,
+                         uint64_t sequence_number, uint64_t file_size),
+    void (*block_add)(void*, uint64_t, uint64_t, uint64_t),
+    bool (*finish)(void*, rocksdb_user_collected_properties_t* properties),
+    void (*get_readable_properties)(
+        void*, rocksdb_user_collected_properties_t* properties),
+    const char* (*name)(void*)) {
+  return new rocksdb_table_properties_collector_t(
+      state, destructor, add_user_key, block_add, finish,
+      get_readable_properties, name);
+}
+
+void rocksdb_options_add_table_properties_collector_factory(
+    rocksdb_options_t* options, void* state, void (*destructor)(void* state),
+    const char* (*name)(void*),
+    rocksdb_table_properties_collector_t* (*create_collector)(
+        void* state, rocksdb_table_properties_collector_context_t* context)) {
+  auto factory = std::make_shared<rocksdb_table_properties_collector_factory_t>(
+      state, destructor, create_collector, name);
+  options->rep.table_properties_collector_factories.emplace_back(factory);
+}
+
 void rocksdb_options_set_create_if_missing(rocksdb_options_t* opt,
                                            unsigned char v) {
   opt->rep.create_if_missing = v;
@@ -4653,7 +4860,6 @@ DB::GetOptions
 DB::GetSortedWalFiles
 DB::RunManualCompaction
 custom cache
-table_properties_collectors
 */
 
 rocksdb_compactionfilter_t* rocksdb_compactionfilter_create(

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -84,6 +84,13 @@ typedef struct rocksdb_compactionfiltercontext_t
     rocksdb_compactionfiltercontext_t;
 typedef struct rocksdb_compactionfilterfactory_t
     rocksdb_compactionfilterfactory_t;
+typedef struct rocksdb_table_properties_t rocksdb_table_properties_t;
+typedef struct rocksdb_user_collected_properties_t
+    rocksdb_user_collected_properties_t;
+typedef struct rocksdb_table_properties_collector_t
+    rocksdb_table_properties_collector_t;
+typedef struct rocksdb_table_properties_collector_factory_context_t
+    rocksdb_table_properties_collector_context_t;
 typedef struct rocksdb_comparator_t rocksdb_comparator_t;
 typedef struct rocksdb_event_listener_t rocksdb_event_listener_t;
 typedef struct rocksdb_dbpath_t rocksdb_dbpath_t;
@@ -1257,6 +1264,9 @@ rocksdb_flushjobinfo_largest_seqno(const rocksdb_flushjobinfo_t*);
 extern ROCKSDB_LIBRARY_API rocksdb_flushreason_t
 rocksdb_flushjobinfo_flushreason(const rocksdb_flushjobinfo_t*);
 
+extern ROCKSDB_LIBRARY_API const rocksdb_table_properties_t*
+rocksdb_flushjobinfo_table_properties(const rocksdb_flushjobinfo_t*);
+
 /* Merge Operator */
 
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_uint64add_merge_operator(
@@ -1818,6 +1828,50 @@ extern ROCKSDB_LIBRARY_API unsigned char rocksdb_options_get_atomic_flush(
 
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_row_cache(
     rocksdb_options_t* opt, rocksdb_cache_t* cache);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_options_add_table_properties_collector_factory(
+    rocksdb_options_t* options, void* state, void (*destructor)(void* state),
+    const char* (*name)(void*),
+    rocksdb_table_properties_collector_t* (*create_collector)(
+        void* state, rocksdb_table_properties_collector_context_t* context));
+
+extern ROCKSDB_LIBRARY_API rocksdb_table_properties_collector_t*
+rocksdb_table_properties_collector_create(
+    void* state, void (*destructor)(void* state),
+    bool (*add_user_key)(void*, const char* key, size_t key_len,
+                         const char* value, size_t value_len, int entry_type,
+                         uint64_t sequence_number, uint64_t file_size),
+    void (*block_add)(void*, uint64_t, uint64_t, uint64_t),
+    bool (*finish)(void*, rocksdb_user_collected_properties_t* properties),
+    void (*get_readable_properties)(
+        void*, rocksdb_user_collected_properties_t* properties),
+    const char* (*name)(void*));
+
+extern ROCKSDB_LIBRARY_API uint32_t
+rocksdb_table_properties_collector_context_get_column_family_id(
+    rocksdb_table_properties_collector_context_t*);
+
+extern ROCKSDB_LIBRARY_API int
+rocksdb_table_properties_collector_context_get_level_at_creation(
+    rocksdb_table_properties_collector_context_t*);
+
+extern ROCKSDB_LIBRARY_API int
+rocksdb_table_properties_collector_context_get_num_levels(
+    rocksdb_table_properties_collector_context_t*);
+
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_table_properties_collector_context_get_last_level_inclusive_max_seqno_threshold(
+    rocksdb_table_properties_collector_context_t*);
+
+extern ROCKSDB_LIBRARY_API const char*
+rocksdb_table_properties_get_user_collected_property(
+    const rocksdb_table_properties_t* table_properties, const char* key);
+extern ROCKSDB_LIBRARY_API void rocksdb_table_properties_destroy(
+    const rocksdb_table_properties_t*);
+
+extern ROCKSDB_LIBRARY_API void rocksdb_user_collected_properties_insert(
+    rocksdb_user_collected_properties_t*, const char*, const char*);
 
 extern ROCKSDB_LIBRARY_API void
 rocksdb_options_add_compact_on_deletion_collector_factory(


### PR DESCRIPTION
This PR extends RocksDB's C API to support TablePropertiesCollector functionality, building on PR #7 which added EventListener support. The implementation allows adding custom table property collectors to RocksDB through its C Foreign Function Interface (FFI), enabling integration with languages like Rust. The PR also includes integration of table properties with the previously added FlushJobInfo functionality.

Stack:

* #7
* __->__ #8 (4e4347eb0da09f90d86bc994a468ce80c2c2c45b)

Rust counterpart: https://github.com/restatedev/rust-rocksdb/pull/9
