### PR TITLE
Expose user properties key enumeration FFI call

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -498,34 +498,40 @@ rocksdb_table_properties_collector_context_get_last_level_inclusive_max_seqno_th
 
 const char* rocksdb_table_properties_get_user_collected_property(
     const rocksdb_table_properties_t* table_properties, const char* key) {
-  UserCollectedProperties properties =
+  const UserCollectedProperties& properties =
       table_properties->rep->user_collected_properties;
-  auto it = properties.find(std::string(key));
+  auto it = properties.find(key);
   if (it != properties.end()) {
-    return strdup(it->second.c_str());
+    return it->second.c_str();
   }
   return nullptr;
 }
 
 const char** rocksdb_table_properties_get_user_collected_property_keys(
-    const rocksdb_table_properties_t* table_properties, size_t* key_count) {
-  UserCollectedProperties properties =
+    const rocksdb_table_properties_t* table_properties, const char* prefix,
+    size_t* key_count) {
+  const UserCollectedProperties& properties =
       table_properties->rep->user_collected_properties;
-  *key_count = properties.size();
 
-  if (properties.empty()) {
+  std::vector<const char*> matches;
+  for (auto pos = properties.lower_bound(prefix);
+       pos != properties.end() &&
+       pos->first.compare(0, strlen(prefix), prefix) == 0;
+       ++pos) {
+    matches.push_back(pos->first.c_str());
+  }
+
+  *key_count = matches.size();
+
+  if (matches.empty()) {
     return nullptr;
   }
 
   const char** keys =
-      static_cast<const char**>(malloc(*key_count * sizeof(char*)));
-
-  size_t i = 0;
-  for (const auto& kv : properties) {
-    keys[i] = strdup(kv.first.c_str());
-    i++;
+      static_cast<const char**>(malloc(matches.size() * sizeof(char*)));
+  for (size_t i = 0; i < matches.size(); i++) {
+    keys[i] = matches[i];
   }
-
   return keys;
 }
 

--- a/db/c.cc
+++ b/db/c.cc
@@ -506,6 +506,27 @@ const char* rocksdb_table_properties_get_user_collected_property(
   return nullptr;
 }
 
+const char** rocksdb_table_properties_get_user_collected_property_keys(
+    const rocksdb_table_properties_t* table_properties, size_t* key_count) {
+  auto properties = table_properties->rep->user_collected_properties;
+  *key_count = properties.size();
+
+  if (properties.empty()) {
+    return nullptr;
+  }
+
+  const char** keys =
+      static_cast<const char**>(malloc(*key_count * sizeof(char*)));
+
+  size_t i = 0;
+  for (const auto& kv : properties) {
+    keys[i] = strdup(kv.first.c_str());
+    i++;
+  }
+
+  return keys;
+}
+
 void rocksdb_table_properties_destroy(
     const rocksdb_table_properties_t* table_properties) {
   delete table_properties;

--- a/db/c.cc
+++ b/db/c.cc
@@ -498,7 +498,8 @@ rocksdb_table_properties_collector_context_get_last_level_inclusive_max_seqno_th
 
 const char* rocksdb_table_properties_get_user_collected_property(
     const rocksdb_table_properties_t* table_properties, const char* key) {
-  auto properties = table_properties->rep->user_collected_properties;
+  UserCollectedProperties properties =
+      table_properties->rep->user_collected_properties;
   auto it = properties.find(std::string(key));
   if (it != properties.end()) {
     return strdup(it->second.c_str());
@@ -508,7 +509,8 @@ const char* rocksdb_table_properties_get_user_collected_property(
 
 const char** rocksdb_table_properties_get_user_collected_property_keys(
     const rocksdb_table_properties_t* table_properties, size_t* key_count) {
-  auto properties = table_properties->rep->user_collected_properties;
+  UserCollectedProperties properties =
+      table_properties->rep->user_collected_properties;
   *key_count = properties.size();
 
   if (properties.empty()) {

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1869,7 +1869,8 @@ rocksdb_table_properties_get_user_collected_property(
     const rocksdb_table_properties_t* table_properties, const char* key);
 extern ROCKSDB_LIBRARY_API const char**
 rocksdb_table_properties_get_user_collected_property_keys(
-    const rocksdb_table_properties_t* table_properties, size_t* key_count);
+    const rocksdb_table_properties_t* table_properties, const char* prefix,
+    size_t* key_count);
 extern ROCKSDB_LIBRARY_API void rocksdb_table_properties_destroy(
     const rocksdb_table_properties_t*);
 

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1867,6 +1867,9 @@ rocksdb_table_properties_collector_context_get_last_level_inclusive_max_seqno_th
 extern ROCKSDB_LIBRARY_API const char*
 rocksdb_table_properties_get_user_collected_property(
     const rocksdb_table_properties_t* table_properties, const char* key);
+extern ROCKSDB_LIBRARY_API const char**
+rocksdb_table_properties_get_user_collected_property_keys(
+    const rocksdb_table_properties_t* table_properties, size_t* key_count);
 extern ROCKSDB_LIBRARY_API void rocksdb_table_properties_destroy(
     const rocksdb_table_properties_t*);
 


### PR DESCRIPTION
Expose a new FFI operation to enumerate the (keys of) a table properties structure's user-collected properties.

- eliminated `UserCollectedProperties` copying
- this removes the need to `strdup` the strings
- added support for prefix filtering when enumerating property keys

Specially ran the new tests with `cargo valgrind`:

```
 Nextest run ID 89ac8bf2-7ef8-4f6c-bf3b-54dfe6a4a35c with nextest profile: default
    Starting 2 tests across 25 binaries (195 tests skipped)
       START             rust-rocksdb::test_event_listener test_event_listener

running 1 test
test test_event_listener ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.69s

        PASS [   3.245s] rust-rocksdb::test_event_listener test_event_listener
       START             rust-rocksdb::test_table_properties test_table_properties_collector

running 1 test
test test_table_properties_collector ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.81s

        PASS [   3.313s] rust-rocksdb::test_table_properties test_table_properties_collector
```