### PR TITLE
Introduce Checkpoint::Export-specific flush mode

### DIFF
--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -479,6 +479,8 @@ class DBImpl : public DB {
   Status Flush(
       const FlushOptions& options,
       const std::vector<ColumnFamilyHandle*>& column_families) override;
+  Status FlushForCheckpointExport(const FlushOptions& options,
+                                  ColumnFamilyHandle* column_family);
   Status FlushWAL(bool sync) override {
     // TODO: plumb Env::IOActivity, Env::IOPriority
     return FlushWAL(WriteOptions(), sync);

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -2019,6 +2019,26 @@ Status DBImpl::Flush(const FlushOptions& flush_options,
   return s;
 }
 
+Status DBImpl::FlushForCheckpointExport(const FlushOptions& flush_options,
+                                        ColumnFamilyHandle* column_family) {
+  auto cfh = static_cast_with_check<ColumnFamilyHandleImpl>(column_family);
+  ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                 "[%s] Checkpoint export flush start.", cfh->GetName().c_str());
+  Status s;
+  if (immutable_db_options_.atomic_flush) {
+    s = AtomicFlushMemTables(flush_options, FlushReason::kCheckpointExport,
+                             {cfh->cfd()});
+  } else {
+    s = FlushMemTable(cfh->cfd(), flush_options,
+                      FlushReason::kCheckpointExport);
+  }
+
+  ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                 "[%s] Checkpoint export flush finished, status: %s\n",
+                 cfh->GetName().c_str(), s.ToString().c_str());
+  return s;
+}
+
 Status DBImpl::RunManualCompaction(
     ColumnFamilyData* cfd, int input_level, int output_level,
     const CompactRangeOptions& compact_range_options, const Slice* begin,
@@ -2757,11 +2777,17 @@ Status DBImpl::WaitForFlushMemTables(
                  (flush_memtable_ids[i] != nullptr &&
                   cfds[i]->imm()->GetEarliestMemTableID() >
                       *flush_memtable_ids[i])) {
-        // Make file ingestion's flush wait until SuperVersion is also updated
-        // since after flush, it does range overlapping check and file level
-        // assignment with the current SuperVersion.
+        // Make file ingestion and checkpoint export flushes wait until
+        // SuperVersion is also updated. For file ingestion, after flush, it
+        // does range overlapping check and file level assignment with the
+        // current SuperVersion.
+        //
+        // For Checkpoint export flush, we wait until SuperVersion is updated to
+        // avoid a race condition where GetColumnFamilyMetaData observes the old
+        // version.
         if (!flush_reason.has_value() ||
-            flush_reason.value() != FlushReason::kExternalFileIngestion ||
+            (flush_reason.value() != FlushReason::kExternalFileIngestion &&
+             flush_reason.value() != FlushReason::kCheckpointExport) ||
             cfds[i]->GetSuperVersion()->imm->GetID() ==
                 cfds[i]->imm()->current()->GetID()) {
           ++num_finished;

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -79,6 +79,8 @@ const char* GetFlushReasonString(FlushReason flush_reason) {
       return "Error Recovery Retry Flush";
     case FlushReason::kWalFull:
       return "WAL Full";
+    case FlushReason::kCheckpointExport:
+      return "Checkpoint Export";
     case FlushReason::kCatchUpAfterErrorRecovery:
       return "Catch Up After Error Recovery";
     default:

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -183,6 +183,7 @@ enum class FlushReason : int {
   kWalFull = 0xd,
   // SwitchMemtable will not be called for this flush reason.
   kCatchUpAfterErrorRecovery = 0xe,
+  kCheckpointExport = 0xf,
 
   // When adding flush reason, make sure to also add it to FlushReason in Java.
 };

--- a/java/src/main/java/org/rocksdb/FlushReason.java
+++ b/java/src/main/java/org/rocksdb/FlushReason.java
@@ -21,6 +21,7 @@ public enum FlushReason {
   ERROR_RECOVERY_RETRY_FLUSH((byte) 0x0c),
   WAL_FULL((byte) 0x0d),
   CATCH_UP_AFTER_ERROR_RECOVERY((byte) 0x0e);
+  CHECKPOINT_EXPORT((byte) 0x0f);
 
   private final byte value;
 

--- a/utilities/checkpoint/checkpoint_impl.cc
+++ b/utilities/checkpoint/checkpoint_impl.cc
@@ -16,6 +16,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "db/db_impl/db_impl.h"
 #include "db/wal_manager.h"
 #include "file/file_util.h"
 #include "file/filename.h"
@@ -340,7 +341,11 @@ Status CheckpointImpl::ExportColumnFamily(
   s = db_->GetEnv()->CreateDir(tmp_export_dir);
 
   if (s.ok()) {
-    s = db_->Flush(ROCKSDB_NAMESPACE::FlushOptions(), handle);
+    DBImpl* db_impl_ = static_cast_with_check<DBImpl>(db_);
+    // Checkpoint export-specific flush is required to ensure that
+    // ExportFilesInMetaData below will observe the latest CF metadata.
+    s = db_impl_->FlushForCheckpointExport(ROCKSDB_NAMESPACE::FlushOptions(),
+                                           handle);
   }
 
   ColumnFamilyMetaData db_metadata;


### PR DESCRIPTION
Introduces a new DBImpl::FlushForCheckpointExport method along with a new flush reason, which avoids a data race where exporting a checkpoint can observe stale metadata.

This is a preliminary fix for https://github.com/facebook/rocksdb/issues/13652