### PR TITLE
Rebase Restate's RocksDB changes on 10.5.1

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -11,6 +11,7 @@
 
 #include <cstdlib>
 #include <map>
+#include <memory>
 #include <unordered_set>
 #include <vector>
 
@@ -35,6 +36,7 @@
 #include "rocksdb/statistics.h"
 #include "rocksdb/status.h"
 #include "rocksdb/table.h"
+#include "rocksdb/table_properties.h"
 #include "rocksdb/universal_compaction.h"
 #include "rocksdb/utilities/backup_engine.h"
 #include "rocksdb/utilities/checkpoint.h"
@@ -79,6 +81,7 @@ using ROCKSDB_NAMESPACE::CuckooTableOptions;
 using ROCKSDB_NAMESPACE::DB;
 using ROCKSDB_NAMESPACE::DBOptions;
 using ROCKSDB_NAMESPACE::DbPath;
+using ROCKSDB_NAMESPACE::EntryType;
 using ROCKSDB_NAMESPACE::Env;
 using ROCKSDB_NAMESPACE::EnvOptions;
 using ROCKSDB_NAMESPACE::EventListener;
@@ -119,6 +122,7 @@ using ROCKSDB_NAMESPACE::Range;
 using ROCKSDB_NAMESPACE::RateLimiter;
 using ROCKSDB_NAMESPACE::ReadOptions;
 using ROCKSDB_NAMESPACE::RestoreOptions;
+using ROCKSDB_NAMESPACE::SequenceNumber;
 using ROCKSDB_NAMESPACE::SequentialFile;
 using ROCKSDB_NAMESPACE::Slice;
 using ROCKSDB_NAMESPACE::SliceParts;
@@ -130,12 +134,15 @@ using ROCKSDB_NAMESPACE::SstFileWriter;
 using ROCKSDB_NAMESPACE::Status;
 using ROCKSDB_NAMESPACE::StderrLogger;
 using ROCKSDB_NAMESPACE::SubcompactionJobInfo;
+using ROCKSDB_NAMESPACE::TableProperties;
+using ROCKSDB_NAMESPACE::TablePropertiesCollector;
 using ROCKSDB_NAMESPACE::TablePropertiesCollectorFactory;
 using ROCKSDB_NAMESPACE::Transaction;
 using ROCKSDB_NAMESPACE::TransactionDB;
 using ROCKSDB_NAMESPACE::TransactionDBOptions;
 using ROCKSDB_NAMESPACE::TransactionLogIterator;
 using ROCKSDB_NAMESPACE::TransactionOptions;
+using ROCKSDB_NAMESPACE::UserCollectedProperties;
 using ROCKSDB_NAMESPACE::WaitForCompactOptions;
 using ROCKSDB_NAMESPACE::WALRecoveryMode;
 using ROCKSDB_NAMESPACE::WritableFile;
@@ -381,6 +388,174 @@ struct rocksdb_compactionfilter_t : public CompactionFilter {
 
   bool IgnoreSnapshots() const override { return ignore_snapshots_; }
 };
+
+/* Table Properties */
+
+struct rocksdb_table_properties_t {
+  const TableProperties* rep;
+};
+
+struct rocksdb_table_properties_collector_factory_context_t {
+  TablePropertiesCollectorFactory::Context* rep;
+};
+
+struct rocksdb_user_collected_properties_t {
+  UserCollectedProperties* rep;
+};
+
+struct rocksdb_table_properties_collector_t : public TablePropertiesCollector {
+  void* state_;
+  void (*destructor_)(void*);
+  bool (*add_user_key_)(void*, const char* key, size_t key_len,
+                        const char* value, size_t value_len, int entry_type,
+                        uint64_t sequence_number, uint64_t file_size);
+  void (*block_add_)(void*, uint64_t, uint64_t, uint64_t);
+  bool (*finish_)(void*, rocksdb_user_collected_properties_t* properties);
+  void (*get_readable_properties_)(
+      void*, rocksdb_user_collected_properties_t* properties);
+  const char* (*name_)(void*);
+
+  rocksdb_table_properties_collector_t(
+      void* state, void (*destructor)(void*),
+      bool (*add_user_key)(void*, const char* key, size_t key_len,
+                           const char* value, size_t value_len, int entry_type,
+                           uint64_t sequence_number, uint64_t file_size),
+      void (*block_add)(void*, uint64_t, uint64_t, uint64_t),
+      bool (*finish)(void*, rocksdb_user_collected_properties_t* properties),
+      void (*get_readable_properties)(
+          void*, rocksdb_user_collected_properties_t* properties),
+      const char* (*name)(void*)) {
+    state_ = state;
+    destructor_ = destructor;
+    add_user_key_ = add_user_key;
+    block_add_ = block_add;
+    finish_ = finish;
+    get_readable_properties_ = get_readable_properties;
+    name_ = name;
+  }
+
+  ~rocksdb_table_properties_collector_t() override { (*destructor_)(state_); }
+
+  Status AddUserKey(const Slice& key, const Slice& value, EntryType entry_type,
+                    SequenceNumber seq, uint64_t file_size) override {
+    bool result = (*add_user_key_)(state_, key.data(), key.size(), value.data(),
+                                   value.size(), entry_type, seq, file_size);
+    if (result) {
+      return Status::OK();
+    } else {
+      return Status::Aborted();
+    }
+  }
+
+  void BlockAdd(uint64_t block_uncomp_bytes,
+                uint64_t block_compressed_bytes_fast,
+                uint64_t block_compressed_bytes_slow) override {
+    if (block_add_ != nullptr) {
+      (*block_add_)(state_, block_uncomp_bytes, block_compressed_bytes_fast,
+                    block_compressed_bytes_slow);
+    }
+  }
+
+  Status Finish(UserCollectedProperties* properties) override {
+    rocksdb_user_collected_properties_t user_collected_properties;
+    user_collected_properties.rep = properties;
+    bool result = (*finish_)(state_, &user_collected_properties);
+    if (result) {
+      return Status::OK();
+    } else {
+      return Status::Aborted();
+    }
+  }
+
+  UserCollectedProperties GetReadableProperties() const override {
+    UserCollectedProperties properties;
+    rocksdb_user_collected_properties_t user_collected_properties;
+    user_collected_properties.rep = &properties;
+    (*get_readable_properties_)(state_, &user_collected_properties);
+    return properties;
+  }
+
+  const char* Name() const override { return (*name_)(state_); }
+};
+
+struct rocksdb_table_properties_collector_factory_t
+    : public TablePropertiesCollectorFactory {
+  void* state_;
+  void (*destructor_)(void*);
+  rocksdb_table_properties_collector_t* (*create_table_properties_collector_)(
+      void*, rocksdb_table_properties_collector_context_t*);
+  const char* (*name_)(void*);
+
+  rocksdb_table_properties_collector_factory_t(
+      void* state, void (*destructor)(void*),
+      rocksdb_table_properties_collector_t* (
+          *create_table_properties_collector)(
+          void*, rocksdb_table_properties_collector_context_t*),
+      const char* (*name)(void*)) {
+    this->state_ = state;
+    this->destructor_ = destructor;
+    this->create_table_properties_collector_ =
+        create_table_properties_collector;
+    this->name_ = name;
+  }
+
+  ~rocksdb_table_properties_collector_factory_t() override {
+    (*destructor_)(state_);
+  }
+
+  TablePropertiesCollector* CreateTablePropertiesCollector(
+      TablePropertiesCollectorFactory::Context context) override {
+    rocksdb_table_properties_collector_context_t cb_context;
+    cb_context.rep = &context;
+    return (*create_table_properties_collector_)(state_, &cb_context);
+  }
+
+  const char* Name() const override { return (*name_)(state_); }
+};
+
+uint32_t rocksdb_table_properties_collector_context_get_column_family_id(
+    rocksdb_table_properties_collector_context_t* context) {
+  return context->rep->column_family_id;
+}
+
+int rocksdb_table_properties_collector_context_get_level_at_creation(
+    rocksdb_table_properties_collector_context_t* context) {
+  return context->rep->level_at_creation;
+}
+
+int rocksdb_table_properties_collector_context_get_num_levels(
+    rocksdb_table_properties_collector_context_t* context) {
+  return context->rep->num_levels;
+}
+
+uint64_t
+rocksdb_table_properties_collector_context_get_last_level_inclusive_max_seqno_threshold(
+    rocksdb_table_properties_collector_context_t* context) {
+  return context->rep->last_level_inclusive_max_seqno_threshold;
+}
+
+const char* rocksdb_table_properties_get_user_collected_property(
+    const rocksdb_table_properties_t* table_properties, const char* key) {
+  auto properties = table_properties->rep->user_collected_properties;
+  auto it = properties.find(std::string(key));
+  if (it != properties.end()) {
+    return strdup(it->second.c_str());
+  }
+  return nullptr;
+}
+
+void rocksdb_table_properties_destroy(
+    const rocksdb_table_properties_t* table_properties) {
+  delete table_properties;
+}
+
+void rocksdb_user_collected_properties_insert(
+    rocksdb_user_collected_properties_t* properties, const char* key,
+    const char* value) {
+  properties->rep->emplace(std::string(key), std::string(value));
+}
+
+/* Compaction Filter Factory */
 
 struct rocksdb_compactionfilterfactory_t : public CompactionFilterFactory {
   void* state_;
@@ -3111,6 +3286,13 @@ uint32_t rocksdb_flushjobinfo_flush_reason(const rocksdb_flushjobinfo_t* info) {
   return static_cast<uint32_t>(info->rep.flush_reason);
 }
 
+const rocksdb_table_properties_t* rocksdb_flushjobinfo_table_properties(
+    const rocksdb_flushjobinfo_t* info) {
+  auto table_properties = new rocksdb_table_properties_t;
+  table_properties->rep = &info->rep.table_properties;
+  return table_properties;
+}
+
 void rocksdb_reset_status(rocksdb_status_ptr_t* status_ptr) {
   auto ptr = status_ptr->rep;
   *ptr = Status::OK();
@@ -3554,6 +3736,31 @@ void rocksdb_options_set_comparator(rocksdb_options_t* opt,
 void rocksdb_options_set_merge_operator(
     rocksdb_options_t* opt, rocksdb_mergeoperator_t* merge_operator) {
   opt->rep.merge_operator = std::shared_ptr<MergeOperator>(merge_operator);
+}
+
+rocksdb_table_properties_collector_t* rocksdb_table_properties_collector_create(
+    void* state, void (*destructor)(void* state),
+    bool (*add_user_key)(void*, const char* key, size_t key_len,
+                         const char* value, size_t value_len, int entry_type,
+                         uint64_t sequence_number, uint64_t file_size),
+    void (*block_add)(void*, uint64_t, uint64_t, uint64_t),
+    bool (*finish)(void*, rocksdb_user_collected_properties_t* properties),
+    void (*get_readable_properties)(
+        void*, rocksdb_user_collected_properties_t* properties),
+    const char* (*name)(void*)) {
+  return new rocksdb_table_properties_collector_t(
+      state, destructor, add_user_key, block_add, finish,
+      get_readable_properties, name);
+}
+
+void rocksdb_options_add_table_properties_collector_factory(
+    rocksdb_options_t* options, void* state, void (*destructor)(void* state),
+    const char* (*name)(void*),
+    rocksdb_table_properties_collector_t* (*create_collector)(
+        void* state, rocksdb_table_properties_collector_context_t* context)) {
+  auto factory = std::make_shared<rocksdb_table_properties_collector_factory_t>(
+      state, destructor, create_collector, name);
+  options->rep.table_properties_collector_factories.emplace_back(factory);
 }
 
 void rocksdb_options_set_create_if_missing(rocksdb_options_t* opt,
@@ -4984,7 +5191,6 @@ DB::GetOptions
 DB::GetSortedWalFiles
 DB::RunManualCompaction
 custom cache
-table_properties_collectors
 */
 
 rocksdb_compactionfilter_t* rocksdb_compactionfilter_create(

--- a/db/c.cc
+++ b/db/c.cc
@@ -82,6 +82,7 @@ using ROCKSDB_NAMESPACE::DbPath;
 using ROCKSDB_NAMESPACE::Env;
 using ROCKSDB_NAMESPACE::EnvOptions;
 using ROCKSDB_NAMESPACE::EventListener;
+using ROCKSDB_NAMESPACE::ExportImportFilesMetaData;
 using ROCKSDB_NAMESPACE::ExternalFileIngestionInfo;
 using ROCKSDB_NAMESPACE::FileLock;
 using ROCKSDB_NAMESPACE::FilterPolicy;
@@ -89,6 +90,7 @@ using ROCKSDB_NAMESPACE::FlushJobInfo;
 using ROCKSDB_NAMESPACE::FlushOptions;
 using ROCKSDB_NAMESPACE::HistogramData;
 using ROCKSDB_NAMESPACE::HyperClockCacheOptions;
+using ROCKSDB_NAMESPACE::ImportColumnFamilyOptions;
 using ROCKSDB_NAMESPACE::InfoLogLevel;
 using ROCKSDB_NAMESPACE::IngestExternalFileOptions;
 using ROCKSDB_NAMESPACE::Iterator;
@@ -245,6 +247,9 @@ struct rocksdb_write_buffer_manager_t {
 struct rocksdb_sst_file_manager_t {
   std::shared_ptr<SstFileManager> rep;
 };
+struct rocksdb_livefile_t {
+  LiveFileMetaData rep;
+};
 struct rocksdb_livefiles_t {
   std::vector<LiveFileMetaData> rep;
 };
@@ -254,6 +259,12 @@ struct rocksdb_column_family_handle_t {
 };
 struct rocksdb_column_family_metadata_t {
   ColumnFamilyMetaData rep;
+};
+struct rocksdb_export_import_files_metadata_t {
+  ExportImportFilesMetaData* rep;
+};
+struct rocksdb_import_column_family_options_t {
+  ImportColumnFamilyOptions rep;
 };
 struct rocksdb_level_metadata_t {
   const LevelMetaData* rep;
@@ -947,6 +958,22 @@ void rocksdb_checkpoint_create(rocksdb_checkpoint_t* checkpoint,
                         std::string(checkpoint_dir), log_size_for_flush));
 }
 
+rocksdb_export_import_files_metadata_t* rocksdb_checkpoint_export_column_family(
+    rocksdb_checkpoint_t* checkpoint,
+    rocksdb_column_family_handle_t* column_family, const char* export_dir,
+    char** errptr) {
+  ExportImportFilesMetaData* metadata = nullptr;
+  if (SaveError(errptr,
+                checkpoint->rep->ExportColumnFamily(
+                    column_family->rep, std::string(export_dir), &metadata))) {
+    return nullptr;
+  }
+  rocksdb_export_import_files_metadata_t* result =
+      new rocksdb_export_import_files_metadata_t;
+  result->rep = metadata;
+  return result;
+}
+
 void rocksdb_checkpoint_object_destroy(rocksdb_checkpoint_t* checkpoint) {
   delete checkpoint->rep;
   delete checkpoint;
@@ -1188,6 +1215,21 @@ rocksdb_column_family_handle_t** rocksdb_create_column_families(
   }
 
   return c_handles;
+}
+
+rocksdb_column_family_handle_t* rocksdb_create_column_family_with_import(
+    rocksdb_t* db, rocksdb_options_t* column_family_options,
+    const char* column_family_name,
+    rocksdb_import_column_family_options_t* import_options,
+    rocksdb_export_import_files_metadata_t* export_import_files_metadata,
+    char** errptr) {
+  rocksdb_column_family_handle_t* handle = new rocksdb_column_family_handle_t;
+  handle->rep = nullptr;
+  SaveError(errptr, db->rep->CreateColumnFamilyWithImport(
+                        ColumnFamilyOptions(column_family_options->rep),
+                        std::string(column_family_name), import_options->rep,
+                        *(export_import_files_metadata->rep), &(handle->rep)));
+  return handle;
 }
 
 void rocksdb_create_column_families_destroy(
@@ -6195,6 +6237,10 @@ void rocksdb_options_set_min_level_to_compress(rocksdb_options_t* opt,
   }
 }
 
+rocksdb_livefiles_t* rocksdb_livefiles_create() {
+  return new rocksdb_livefiles_t;
+}
+
 int rocksdb_livefiles_count(const rocksdb_livefiles_t* lf) {
   return static_cast<int>(lf->rep.size());
 }
@@ -6206,6 +6252,16 @@ const char* rocksdb_livefiles_column_family_name(const rocksdb_livefiles_t* lf,
 
 const char* rocksdb_livefiles_name(const rocksdb_livefiles_t* lf, int index) {
   return lf->rep[index].name.c_str();
+}
+
+const char* rocksdb_livefiles_directory(const rocksdb_livefiles_t* lf,
+                                        int index) {
+  if (lf->rep[index].directory.empty()) {
+    // db_path is deprecated but still returned by some code paths
+    return lf->rep[index].db_path.c_str();
+  } else {
+    return lf->rep[index].directory.c_str();
+  }
 }
 
 int rocksdb_livefiles_level(const rocksdb_livefiles_t* lf, int index) {
@@ -6228,6 +6284,16 @@ const char* rocksdb_livefiles_largestkey(const rocksdb_livefiles_t* lf,
   return lf->rep[index].largestkey.data();
 }
 
+uint64_t rocksdb_livefiles_smallest_seqno(const rocksdb_livefiles_t* lf,
+                                          int index) {
+  return lf->rep[index].smallest_seqno;
+}
+
+uint64_t rocksdb_livefiles_largest_seqno(const rocksdb_livefiles_t* lf,
+                                         int index) {
+  return lf->rep[index].largest_seqno;
+}
+
 uint64_t rocksdb_livefiles_entries(const rocksdb_livefiles_t* lf, int index) {
   return lf->rep[index].num_entries;
 }
@@ -6237,6 +6303,71 @@ uint64_t rocksdb_livefiles_deletions(const rocksdb_livefiles_t* lf, int index) {
 }
 
 void rocksdb_livefiles_destroy(const rocksdb_livefiles_t* lf) { delete lf; }
+
+rocksdb_livefile_t* rocksdb_livefile_create() { return new rocksdb_livefile_t; }
+
+void rocksdb_livefile_set_column_family_name(rocksdb_livefile_t* lf,
+                                             const char* column_family_name) {
+  lf->rep.column_family_name = std::string(column_family_name);
+}
+
+void rocksdb_livefile_set_level(rocksdb_livefile_t* lf, int level) {
+  lf->rep.level = level;
+}
+
+void rocksdb_livefile_set_name(rocksdb_livefile_t* lf, const char* name) {
+  lf->rep.name = std::string(name);
+}
+
+void rocksdb_livefile_set_directory(rocksdb_livefile_t* lf,
+                                    const char* directory) {
+  lf->rep.directory = std::string(directory);
+  lf->rep.db_path = std::string(directory);  // deprecated but still needed
+}
+
+void rocksdb_livefile_set_size(rocksdb_livefile_t* lf, size_t size) {
+  lf->rep.size = size;
+}
+
+void rocksdb_livefile_set_smallest_key(rocksdb_livefile_t* lf,
+                                       const char* smallest_key,
+                                       size_t smallest_key_len) {
+  lf->rep.smallestkey = std::string(smallest_key, smallest_key_len);
+}
+
+void rocksdb_livefile_set_largest_key(rocksdb_livefile_t* lf,
+                                      const char* largest_key,
+                                      size_t largest_key_len) {
+  lf->rep.largestkey = std::string(largest_key, largest_key_len);
+}
+
+void rocksdb_livefile_set_smallest_seqno(rocksdb_livefile_t* lf,
+                                         uint64_t smallest_seqno) {
+  lf->rep.smallest_seqno = smallest_seqno;
+}
+
+void rocksdb_livefile_set_largest_seqno(rocksdb_livefile_t* lf,
+                                        uint64_t largest_seqno) {
+  lf->rep.largest_seqno = largest_seqno;
+}
+
+void rocksdb_livefile_set_num_entries(rocksdb_livefile_t* lf,
+                                      uint64_t num_entries) {
+  lf->rep.num_entries = num_entries;
+}
+
+void rocksdb_livefile_set_num_deletions(rocksdb_livefile_t* lf,
+                                        uint64_t num_deletions) {
+  lf->rep.num_deletions = num_deletions;
+}
+
+void rocksdb_livefile_destroy(rocksdb_livefile_t* lf) { delete lf; }
+
+void rocksdb_livefiles_add(rocksdb_livefiles_t* lf,
+                           rocksdb_livefile_t* livefile) {
+  lf->rep.push_back(std::move(livefile->rep));
+  delete livefile;
+}
 
 void rocksdb_get_options_from_string(const rocksdb_options_t* base_options,
                                      const char* opts_str,
@@ -6386,6 +6517,58 @@ char* rocksdb_sst_file_metadata_get_largestkey(
     rocksdb_sst_file_metadata_t* file_meta, size_t* key_len) {
   *key_len = file_meta->rep->largestkey.size();
   return CopyString(file_meta->rep->largestkey);
+}
+
+rocksdb_import_column_family_options_t*
+rocksdb_import_column_family_options_create() {
+  return new rocksdb_import_column_family_options_t;
+}
+
+void rocksdb_import_column_family_options_set_move_files(
+    rocksdb_import_column_family_options_t* opt, unsigned char v) {
+  opt->rep.move_files = v;
+}
+
+void rocksdb_import_column_family_options_destroy(
+    rocksdb_import_column_family_options_t* metadata) {
+  delete metadata;
+}
+
+rocksdb_export_import_files_metadata_t*
+rocksdb_export_import_files_metadata_create() {
+  auto metadata = new rocksdb_export_import_files_metadata_t;
+  metadata->rep = new ExportImportFilesMetaData;
+  return metadata;
+}
+
+char* rocksdb_export_import_files_metadata_get_db_comparator_name(
+    rocksdb_export_import_files_metadata_t* metadata) {
+  return strdup(metadata->rep->db_comparator_name.c_str());
+}
+
+void rocksdb_export_import_files_metadata_set_db_comparator_name(
+    rocksdb_export_import_files_metadata_t* metadata, const char* name) {
+  metadata->rep->db_comparator_name = std::string(name);
+}
+
+rocksdb_livefiles_t* rocksdb_export_import_files_metadata_get_files(
+    rocksdb_export_import_files_metadata_t* export_import_metadata) {
+  auto files = new rocksdb_livefiles_t;
+  files->rep = std::vector(export_import_metadata->rep->files);
+  return files;
+}
+
+void rocksdb_export_import_files_metadata_set_files(
+    rocksdb_export_import_files_metadata_t* metadata,
+    rocksdb_livefiles_t* files) {
+  metadata->rep->files = std::move(files->rep);
+  delete files;
+}
+
+void rocksdb_export_import_files_metadata_destroy(
+    rocksdb_export_import_files_metadata_t* metadata) {
+  delete metadata->rep;
+  delete metadata;
 }
 
 /* Transactions */

--- a/db/c.cc
+++ b/db/c.cc
@@ -536,12 +536,41 @@ rocksdb_table_properties_collector_context_get_last_level_inclusive_max_seqno_th
 
 const char* rocksdb_table_properties_get_user_collected_property(
     const rocksdb_table_properties_t* table_properties, const char* key) {
-  auto properties = table_properties->rep->user_collected_properties;
-  auto it = properties.find(std::string(key));
+  const UserCollectedProperties& properties =
+      table_properties->rep->user_collected_properties;
+  auto it = properties.find(key);
   if (it != properties.end()) {
-    return strdup(it->second.c_str());
+    return it->second.c_str();
   }
   return nullptr;
+}
+
+const char** rocksdb_table_properties_get_user_collected_property_keys(
+    const rocksdb_table_properties_t* table_properties, const char* prefix,
+    size_t* key_count) {
+  const UserCollectedProperties& properties =
+      table_properties->rep->user_collected_properties;
+
+  std::vector<const char*> matches;
+  for (auto pos = properties.lower_bound(prefix);
+       pos != properties.end() &&
+       pos->first.compare(0, strlen(prefix), prefix) == 0;
+       ++pos) {
+    matches.push_back(pos->first.c_str());
+  }
+
+  *key_count = matches.size();
+
+  if (matches.empty()) {
+    return nullptr;
+  }
+
+  const char** keys =
+      static_cast<const char**>(malloc(matches.size() * sizeof(char*)));
+  for (size_t i = 0; i < matches.size(); i++) {
+    keys[i] = matches[i];
+  }
+  return keys;
 }
 
 void rocksdb_table_properties_destroy(

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -1036,6 +1036,94 @@ int main(int argc, char** argv) {
     rocksdb_options_set_error_if_exists(options, 1);
   }
 
+  StartPhase("checkpoint_export_column_family");
+  {
+    static char cf_export_path[200];
+    static char db_import_path[200];
+
+    snprintf(cf_export_path, sizeof(cf_export_path),
+             "%s/rocksdb_c_test-%d-cf_export-%d", GetTempDir(),
+             ((int)geteuid()), ((int)getpid()));
+    snprintf(db_import_path, sizeof(dbname),
+             "%s/rocksdb_c_test-%d-db_cf_import-%d", GetTempDir(),
+             ((int)geteuid()), ((int)getpid()));
+
+    // Create column families
+    rocksdb_options_t* db_options = rocksdb_options_create();
+    rocksdb_column_family_handle_t* cf_export =
+        rocksdb_create_column_family(db, db_options, "cf_export", &err);
+    CheckNoError(err);
+
+    // Put data into column families
+    rocksdb_writeoptions_t* write_options = rocksdb_writeoptions_create();
+    rocksdb_put_cf(db, write_options, cf_export, "k1", 2, "v1", 2, &err);
+    CheckNoError(err);
+    rocksdb_put_cf(db, write_options, cf_export, "k2", 2, "v2", 2, &err);
+    CheckNoError(err);
+
+    // Create checkpoint object
+    rocksdb_checkpoint_t* checkpoint =
+        rocksdb_checkpoint_object_create(db, &err);
+    CheckNoError(err);
+
+    // Export column family
+    rocksdb_export_import_files_metadata_t* export_metadata =
+        rocksdb_checkpoint_export_column_family(checkpoint, cf_export,
+                                                cf_export_path, &err);
+    CheckNoError(err);
+    const char* comparator_name =
+        rocksdb_export_import_files_metadata_get_db_comparator_name(
+            export_metadata);
+    CheckEqual("leveldb.BytewiseComparator", comparator_name, 26);
+    rocksdb_free((void*)comparator_name);
+
+    rocksdb_checkpoint_object_destroy(checkpoint);
+    rocksdb_drop_column_family(db, cf_export, &err);
+    CheckNoError(err);
+    rocksdb_column_family_handle_destroy(cf_export);
+
+    // Open a new database into which we will import the exported CF into
+    rocksdb_options_set_create_if_missing(db_options, 1);
+    rocksdb_options_set_error_if_exists(db_options, 1);
+    rocksdb_t* db_import = rocksdb_open(db_options, db_import_path, &err);
+    CheckNoError(err);
+
+    // Import column family
+    rocksdb_import_column_family_options_t* import_options =
+        rocksdb_import_column_family_options_create();
+    rocksdb_column_family_handle_t* cf_import =
+        rocksdb_create_column_family_with_import(db_import, db_options,
+                                                 "cf_import", import_options,
+                                                 export_metadata, &err);
+    CheckNoError(err);
+    rocksdb_import_column_family_options_destroy(import_options);
+    rocksdb_export_import_files_metadata_destroy(export_metadata);
+
+    // Verify imported data
+    rocksdb_readoptions_t* read_options = rocksdb_readoptions_create();
+    size_t val_len;
+    char* val = rocksdb_get_cf(db_import, read_options, cf_import, "k1", 2,
+                               &val_len, &err);
+    CheckNoError(err);
+    CheckEqual("v1", val, val_len);
+    free(val);
+
+    val = rocksdb_get_cf(db_import, read_options, cf_import, "k2", 2, &val_len,
+                         &err);
+    CheckNoError(err);
+    CheckEqual("v2", val, val_len);
+    free(val);
+
+    // Clean up
+    rocksdb_column_family_handle_destroy(cf_import);
+    cf_import = NULL;
+    rocksdb_close(db_import);
+    rocksdb_destroy_db(db_options, db_import_path, &err);
+    CheckNoError(err);
+    rocksdb_options_destroy(db_options);
+    db_options = NULL;
+  }
+
   StartPhase("compactall");
   rocksdb_compact_range(db, NULL, 0, NULL, 0);
   CheckGet(db, roptions, "foo", "hello");

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -86,6 +86,13 @@ typedef struct rocksdb_compactionfiltercontext_t
     rocksdb_compactionfiltercontext_t;
 typedef struct rocksdb_compactionfilterfactory_t
     rocksdb_compactionfilterfactory_t;
+typedef struct rocksdb_table_properties_t rocksdb_table_properties_t;
+typedef struct rocksdb_user_collected_properties_t
+    rocksdb_user_collected_properties_t;
+typedef struct rocksdb_table_properties_collector_t
+    rocksdb_table_properties_collector_t;
+typedef struct rocksdb_table_properties_collector_factory_context_t
+    rocksdb_table_properties_collector_context_t;
 typedef struct rocksdb_comparator_t rocksdb_comparator_t;
 typedef struct rocksdb_dbpath_t rocksdb_dbpath_t;
 typedef struct rocksdb_env_t rocksdb_env_t;
@@ -1191,6 +1198,8 @@ extern ROCKSDB_LIBRARY_API void rocksdb_reset_status(
     rocksdb_status_ptr_t* status_ptr);
 extern ROCKSDB_LIBRARY_API uint32_t
 rocksdb_flushjobinfo_flush_reason(const rocksdb_flushjobinfo_t* info);
+extern ROCKSDB_LIBRARY_API const rocksdb_table_properties_t*
+rocksdb_flushjobinfo_table_properties(const rocksdb_flushjobinfo_t*);
 
 /* Compaction job info */
 extern ROCKSDB_LIBRARY_API void rocksdb_compactionjobinfo_status(
@@ -1933,6 +1942,50 @@ extern ROCKSDB_LIBRARY_API unsigned char rocksdb_options_get_atomic_flush(
 
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_row_cache(
     rocksdb_options_t* opt, rocksdb_cache_t* cache);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_options_add_table_properties_collector_factory(
+    rocksdb_options_t* options, void* state, void (*destructor)(void* state),
+    const char* (*name)(void*),
+    rocksdb_table_properties_collector_t* (*create_collector)(
+        void* state, rocksdb_table_properties_collector_context_t* context));
+
+extern ROCKSDB_LIBRARY_API rocksdb_table_properties_collector_t*
+rocksdb_table_properties_collector_create(
+    void* state, void (*destructor)(void* state),
+    bool (*add_user_key)(void*, const char* key, size_t key_len,
+                         const char* value, size_t value_len, int entry_type,
+                         uint64_t sequence_number, uint64_t file_size),
+    void (*block_add)(void*, uint64_t, uint64_t, uint64_t),
+    bool (*finish)(void*, rocksdb_user_collected_properties_t* properties),
+    void (*get_readable_properties)(
+        void*, rocksdb_user_collected_properties_t* properties),
+    const char* (*name)(void*));
+
+extern ROCKSDB_LIBRARY_API uint32_t
+rocksdb_table_properties_collector_context_get_column_family_id(
+    rocksdb_table_properties_collector_context_t*);
+
+extern ROCKSDB_LIBRARY_API int
+rocksdb_table_properties_collector_context_get_level_at_creation(
+    rocksdb_table_properties_collector_context_t*);
+
+extern ROCKSDB_LIBRARY_API int
+rocksdb_table_properties_collector_context_get_num_levels(
+    rocksdb_table_properties_collector_context_t*);
+
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_table_properties_collector_context_get_last_level_inclusive_max_seqno_threshold(
+    rocksdb_table_properties_collector_context_t*);
+
+extern ROCKSDB_LIBRARY_API const char*
+rocksdb_table_properties_get_user_collected_property(
+    const rocksdb_table_properties_t* table_properties, const char* key);
+extern ROCKSDB_LIBRARY_API void rocksdb_table_properties_destroy(
+    const rocksdb_table_properties_t*);
+
+extern ROCKSDB_LIBRARY_API void rocksdb_user_collected_properties_insert(
+    rocksdb_user_collected_properties_t*, const char*, const char*);
 
 extern ROCKSDB_LIBRARY_API void
 rocksdb_options_add_compact_on_deletion_collector_factory(

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -113,10 +113,15 @@ typedef struct rocksdb_writebatch_wi_t rocksdb_writebatch_wi_t;
 typedef struct rocksdb_writeoptions_t rocksdb_writeoptions_t;
 typedef struct rocksdb_universal_compaction_options_t
     rocksdb_universal_compaction_options_t;
+typedef struct rocksdb_livefile_t rocksdb_livefile_t;
 typedef struct rocksdb_livefiles_t rocksdb_livefiles_t;
 typedef struct rocksdb_column_family_handle_t rocksdb_column_family_handle_t;
 typedef struct rocksdb_column_family_metadata_t
     rocksdb_column_family_metadata_t;
+typedef struct rocksdb_import_column_family_options_t
+    rocksdb_import_column_family_options_t;
+typedef struct rocksdb_export_import_files_metadata_t
+    rocksdb_export_import_files_metadata_t;
 typedef struct rocksdb_level_metadata_t rocksdb_level_metadata_t;
 typedef struct rocksdb_sst_file_metadata_t rocksdb_sst_file_metadata_t;
 typedef struct rocksdb_envoptions_t rocksdb_envoptions_t;
@@ -377,6 +382,12 @@ extern ROCKSDB_LIBRARY_API void rocksdb_checkpoint_create(
     rocksdb_checkpoint_t* checkpoint, const char* checkpoint_dir,
     uint64_t log_size_for_flush, char** errptr);
 
+extern ROCKSDB_LIBRARY_API rocksdb_export_import_files_metadata_t*
+rocksdb_checkpoint_export_column_family(
+    rocksdb_checkpoint_t* checkpoint,
+    rocksdb_column_family_handle_t* column_family, const char* export_dir,
+    char** errptr);
+
 extern ROCKSDB_LIBRARY_API void rocksdb_checkpoint_object_destroy(
     rocksdb_checkpoint_t* checkpoint);
 
@@ -436,6 +447,13 @@ rocksdb_create_column_families(rocksdb_t* db,
 
 extern ROCKSDB_LIBRARY_API void rocksdb_create_column_families_destroy(
     rocksdb_column_family_handle_t** list);
+
+extern ROCKSDB_LIBRARY_API rocksdb_column_family_handle_t*
+rocksdb_create_column_family_with_import(
+    rocksdb_t* db, rocksdb_options_t* column_family_options,
+    const char* column_family_name,
+    rocksdb_import_column_family_options_t* import_options,
+    rocksdb_export_import_files_metadata_t* metadata, char** errptr);
 
 extern ROCKSDB_LIBRARY_API rocksdb_column_family_handle_t*
 rocksdb_create_column_family_with_ttl(
@@ -2673,11 +2691,15 @@ rocksdb_fifo_compaction_options_get_max_table_files_size(
 extern ROCKSDB_LIBRARY_API void rocksdb_fifo_compaction_options_destroy(
     rocksdb_fifo_compaction_options_t* fifo_opts);
 
+extern ROCKSDB_LIBRARY_API rocksdb_livefiles_t* rocksdb_livefiles_create(void);
+
 extern ROCKSDB_LIBRARY_API int rocksdb_livefiles_count(
     const rocksdb_livefiles_t*);
 extern ROCKSDB_LIBRARY_API const char* rocksdb_livefiles_column_family_name(
     const rocksdb_livefiles_t*, int index);
 extern ROCKSDB_LIBRARY_API const char* rocksdb_livefiles_name(
+    const rocksdb_livefiles_t*, int index);
+extern ROCKSDB_LIBRARY_API const char* rocksdb_livefiles_directory(
     const rocksdb_livefiles_t*, int index);
 extern ROCKSDB_LIBRARY_API int rocksdb_livefiles_level(
     const rocksdb_livefiles_t*, int index);
@@ -2688,11 +2710,44 @@ extern ROCKSDB_LIBRARY_API const char* rocksdb_livefiles_smallestkey(
 extern ROCKSDB_LIBRARY_API const char* rocksdb_livefiles_largestkey(
     const rocksdb_livefiles_t*, int index, size_t* size);
 extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_livefiles_smallest_seqno(const rocksdb_livefiles_t*, int index);
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_livefiles_largest_seqno(const rocksdb_livefiles_t*, int index);
+extern ROCKSDB_LIBRARY_API uint64_t
 rocksdb_livefiles_entries(const rocksdb_livefiles_t*, int index);
 extern ROCKSDB_LIBRARY_API uint64_t
 rocksdb_livefiles_deletions(const rocksdb_livefiles_t*, int index);
 extern ROCKSDB_LIBRARY_API void rocksdb_livefiles_destroy(
     const rocksdb_livefiles_t*);
+
+extern ROCKSDB_LIBRARY_API rocksdb_livefile_t* rocksdb_livefile_create(void);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_column_family_name(
+    rocksdb_livefile_t*, const char*);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_level(rocksdb_livefile_t*,
+                                                           int);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_name(rocksdb_livefile_t*,
+                                                          const char*);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_directory(
+    rocksdb_livefile_t*, const char*);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_size(rocksdb_livefile_t*,
+                                                          size_t);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_smallest_key(
+    rocksdb_livefile_t*, const char*, size_t);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_largest_key(
+    rocksdb_livefile_t*, const char*, size_t);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_smallest_seqno(
+    rocksdb_livefile_t*, uint64_t);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_largest_seqno(
+    rocksdb_livefile_t*, uint64_t);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_num_entries(
+    rocksdb_livefile_t*, uint64_t);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_set_num_deletions(
+    rocksdb_livefile_t*, uint64_t);
+extern ROCKSDB_LIBRARY_API void rocksdb_livefile_destroy(rocksdb_livefile_t*);
+
+// Takes ownership of the livefile being added.
+extern ROCKSDB_LIBRARY_API void rocksdb_livefiles_add(rocksdb_livefiles_t*,
+                                                      rocksdb_livefile_t*);
 
 /* Utility Helpers */
 
@@ -2713,6 +2768,39 @@ extern ROCKSDB_LIBRARY_API void rocksdb_delete_file_in_range_cf(
 
 extern ROCKSDB_LIBRARY_API rocksdb_column_family_metadata_t*
 rocksdb_get_column_family_metadata(rocksdb_t* db);
+
+extern ROCKSDB_LIBRARY_API rocksdb_import_column_family_options_t*
+rocksdb_import_column_family_options_create(void);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_import_column_family_options_set_move_files(
+    rocksdb_import_column_family_options_t*, unsigned char);
+
+extern ROCKSDB_LIBRARY_API void rocksdb_import_column_family_options_destroy(
+    rocksdb_import_column_family_options_t*);
+
+extern ROCKSDB_LIBRARY_API rocksdb_export_import_files_metadata_t*
+rocksdb_export_import_files_metadata_create(void);
+
+// Returns a copy of C-allocated NUL-terminated string.
+extern ROCKSDB_LIBRARY_API char*
+rocksdb_export_import_files_metadata_get_db_comparator_name(
+    rocksdb_export_import_files_metadata_t*);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_export_import_files_metadata_set_db_comparator_name(
+    rocksdb_export_import_files_metadata_t*, const char*);
+
+extern ROCKSDB_LIBRARY_API rocksdb_livefiles_t*
+rocksdb_export_import_files_metadata_get_files(
+    rocksdb_export_import_files_metadata_t*);
+
+// Takes ownership of the rocksdb_livefiles_t being added.
+extern ROCKSDB_LIBRARY_API void rocksdb_export_import_files_metadata_set_files(
+    rocksdb_export_import_files_metadata_t*, rocksdb_livefiles_t*);
+
+extern ROCKSDB_LIBRARY_API void rocksdb_export_import_files_metadata_destroy(
+    rocksdb_export_import_files_metadata_t*);
 
 /**
  * Returns the rocksdb_column_family_metadata_t of the specified

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -1981,6 +1981,10 @@ rocksdb_table_properties_collector_context_get_last_level_inclusive_max_seqno_th
 extern ROCKSDB_LIBRARY_API const char*
 rocksdb_table_properties_get_user_collected_property(
     const rocksdb_table_properties_t* table_properties, const char* key);
+extern ROCKSDB_LIBRARY_API const char**
+rocksdb_table_properties_get_user_collected_property_keys(
+    const rocksdb_table_properties_t* table_properties, const char* prefix,
+    size_t* key_count);
 extern ROCKSDB_LIBRARY_API void rocksdb_table_properties_destroy(
     const rocksdb_table_properties_t*);
 


### PR DESCRIPTION
This PR adds Restate's non-upstreamed RocksDB changes on top of the base 10.5.1 branch:

- [Expose C bindings for Column Family export/import](https://github.com/restatedev/rocksdb/pull/12/commits/a4144405d5ad668bf8efd86860b06d18be88720c) a4144405d5ad668bf8efd86860b06d18be88720c
- [Add FFI TablePropertiesCollector support](https://github.com/restatedev/rocksdb/pull/12/commits/78d5c44ef4f6ec3b4f19055adac995ddd8e96360) 78d5c44ef4f6ec3b4f19055adac995ddd8e96360
- [Expose user properties key enumeration FFI call](https://github.com/restatedev/rocksdb/pull/12/commits/582fdfa8ce7bedc5bbdb743b76211f8db2c8f194) 582fdfa8ce7bedc5bbdb743b76211f8db2c8f194