### PR TITLE
Rebase Restate changes onto RocksDB 10.9.1

### DIFF
--- a/.github/workflows/pr-jobs.yml
+++ b/.github/workflows/pr-jobs.yml
@@ -1,5 +1,11 @@
-name: facebook/rocksdb/pr-jobs
-on: [push, pull_request]
+name: restatedev/rocksdb/pr-jobs
+on:
+  push:
+    branches:
+      - 'restate-*'
+  pull_request:
+    branches:
+      - 'restate-*'
 permissions: {}
 jobs:
   # NOTE: multiple workflows would be recommended, but the current GHA UI in
@@ -8,7 +14,7 @@ jobs:
   # workflow minimizes the problem because it will be suspicious if there are
   # no GHA results.
   #
-  # The if: ${{ github.repository_owner == 'facebook' }} lines prevent the
+  # The if: ${{ github.repository_owner == 'restatedev' }} lines prevent the
   # jobs from attempting to run on repo forks, because of a few problems:
   # * runs-on labels are repository (owner) specific, so the job might wait
   # for days waiting for a runner that simply isn't available.
@@ -30,8 +36,8 @@ jobs:
 
   # ======================== Fast Initial Checks ====================== #
   check-format-and-targets:
-    if: ${{ github.repository_owner == 'facebook' }}
-    runs-on: ubuntu-24.04
+    if: ${{ github.repository_owner == 'restatedev' }}
+    runs-on: warp-ubuntu-latest-x64-4x
     steps:
     - uses: actions/checkout@v4.1.0
       with:
@@ -62,7 +68,7 @@ jobs:
         SANITY_CHECK=1 LONG_TEST=1 tools/check_format_compatible.sh
   # ========================= Linux With Tests ======================== #
   build-linux:
-    if: ${{ github.repository_owner == 'facebook' }}
+    if: false
     runs-on:
       labels: 16-core-ubuntu
     container:
@@ -74,7 +80,7 @@ jobs:
     - run: make V=1 J=32 -j32 check
     - uses: "./.github/actions/post-steps"
   build-linux-cmake-mingw:
-    if: ${{ github.repository_owner == 'facebook' }}
+    if: false
     runs-on:
       labels: 4-core-ubuntu
     container:
@@ -93,7 +99,7 @@ jobs:
         mkdir build && cd build && cmake -DJNI=1 -DWITH_GFLAGS=OFF .. -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_SYSTEM_NAME=Windows && make -j4 rocksdb rocksdbjni
     - uses: "./.github/actions/post-steps"
   build-linux-make-with-folly:
-    if: ${{ github.repository_owner == 'facebook' }}
+    if: false
     runs-on:
       labels: 16-core-ubuntu
     container:
@@ -111,7 +117,7 @@ jobs:
     - run: USE_FOLLY=1 LIB_MODE=static V=1 make -j32 check
     - uses: "./.github/actions/post-steps"
   build-linux-make-with-folly-lite-no-test:
-    if: ${{ github.repository_owner == 'facebook' }}
+    if: false
     runs-on:
       labels: 16-core-ubuntu
     container:
@@ -124,7 +130,7 @@ jobs:
     - run: USE_FOLLY_LITE=1 EXTRA_CXXFLAGS=-DGLOG_USE_GLOG_EXPORT V=1 make -j32 all
     - uses: "./.github/actions/post-steps"
   build-linux-cmake-with-folly-coroutines:
-    if: ${{ github.repository_owner == 'facebook' }}
+    if: false
     runs-on:
       labels: 16-core-ubuntu
     container:
@@ -142,7 +148,7 @@ jobs:
     - run: "(mkdir build && cd build && cmake -DUSE_COROUTINES=1 -DWITH_GFLAGS=1 -DROCKSDB_BUILD_SHARED=0 .. && make VERBOSE=1 -j20 && ctest -j20)"
     - uses: "./.github/actions/post-steps"
   build-linux-cmake-with-benchmark-no-thread-status:
-    if: ${{ github.repository_owner == 'facebook' }}
+    if: false
     runs-on:
       labels: 16-core-ubuntu
     container:
@@ -154,7 +160,7 @@ jobs:
     - run: mkdir build && cd build && cmake -DWITH_GFLAGS=1 -DWITH_BENCHMARK=1 -DCMAKE_CXX_FLAGS=-DNROCKSDB_THREAD_STATUS .. && make VERBOSE=1 -j20 && ctest -j20
     - uses: "./.github/actions/post-steps"
   build-linux-encrypted_env-no_compression:
-    if: ${{ github.repository_owner == 'facebook' }}
+    if: false
     runs-on:
       labels: 16-core-ubuntu
     container:
@@ -168,9 +174,8 @@ jobs:
     - uses: "./.github/actions/post-steps"
   # ======================== Linux No Test Runs ======================= #
   build-linux-release:
-    if: ${{ github.repository_owner == 'facebook' }}
-    runs-on:
-      labels: 16-core-ubuntu
+    if: ${{ github.repository_owner == 'restatedev' }}
+    runs-on: warp-ubuntu-latest-x64-16x
     container:
       image: ghcr.io/facebook/rocksdb_ubuntu:22.1
       options: --shm-size=16gb
@@ -194,7 +199,7 @@ jobs:
     - run: if ./trace_analyzer --version; then false; else true; fi
     - uses: "./.github/actions/post-steps"
   build-linux-clang-13-no_test_run:
-    if: ${{ github.repository_owner == 'facebook' }}
+    if: false
     runs-on:
       labels: 8-core-ubuntu
     container:
@@ -210,7 +215,7 @@ jobs:
     - run: CC=clang-13 CXX=clang++-13 USE_CLANG=1 EXTRA_CXXFLAGS=-stdlib=libc++ EXTRA_LDFLAGS=-stdlib=libc++ DEBUG_LEVEL=0 make -j32 shared_lib
     - uses: "./.github/actions/post-steps"
   build-linux-clang-18-no_test_run:
-    if: ${{ github.repository_owner == 'facebook' }}
+    if: false
     runs-on:
       labels: 16-core-ubuntu
     container:
@@ -224,7 +229,7 @@ jobs:
     - run: CC=clang-18 CXX=clang++-18 USE_CLANG=1 DEBUG_LEVEL=0 make -j32 release
     - uses: "./.github/actions/post-steps"
   build-linux-gcc-14-no_test_run:
-    if: ${{ github.repository_owner == 'facebook' }}
+    if: false
     runs-on:
       labels: 16-core-ubuntu
     container:
@@ -238,9 +243,8 @@ jobs:
 
   # ======================== Linux Other Checks ======================= #
   build-linux-clang18-clang-analyze:
-    if: ${{ github.repository_owner == 'facebook' }}
-    runs-on:
-      labels: 16-core-ubuntu
+    if: ${{ github.repository_owner == 'restatedev' }}
+    runs-on: warp-ubuntu-latest-x64-16x
     container:
       image: ghcr.io/facebook/rocksdb_ubuntu:24.0
       options: --shm-size=16gb
@@ -257,7 +261,7 @@ jobs:
         name: scan-build-report
         path: scan_build_report.tar.gz
   build-linux-unity-and-headers:
-    if: ${{ github.repository_owner == 'facebook' }}
+    if: false
     runs-on:
       labels: 4-core-ubuntu
     container:
@@ -271,7 +275,7 @@ jobs:
     - run: make V=1 -j8 -k check-headers
     - uses: "./.github/actions/post-steps"
   build-linux-mini-crashtest:
-    if: ${{ github.repository_owner == 'facebook' }}
+    if: false
     runs-on:
       labels: 4-core-ubuntu
     container:
@@ -284,7 +288,7 @@ jobs:
     - uses: "./.github/actions/post-steps"
   # ======================= Linux with Sanitizers ===================== #
   build-linux-clang18-asan-ubsan:
-    if: ${{ github.repository_owner == 'facebook' }}
+    if: false
     runs-on:
       labels: 32-core-ubuntu
     container:
@@ -296,7 +300,7 @@ jobs:
     - run: COMPILE_WITH_ASAN=1 COMPILE_WITH_UBSAN=1 CC=clang-18 CXX=clang++-18 ROCKSDB_DISABLE_ALIGNED_NEW=1 USE_CLANG=1 make V=1 -j40 check
     - uses: "./.github/actions/post-steps"
   build-linux-clang18-mini-tsan:
-    if: ${{ github.repository_owner == 'facebook' }}
+    if: false
     runs-on:
       labels: 32-core-ubuntu
     container:
@@ -308,7 +312,7 @@ jobs:
     - run: COMPILE_WITH_TSAN=1 CC=clang-18 CXX=clang++-18 ROCKSDB_DISABLE_ALIGNED_NEW=1 USE_CLANG=1 make V=1 -j32 check
     - uses: "./.github/actions/post-steps"
   build-linux-static_lib-alt_namespace-status_checked:
-    if: ${{ github.repository_owner == 'facebook' }}
+    if: false
     runs-on:
       labels: 16-core-ubuntu
     container:
@@ -321,7 +325,7 @@ jobs:
     - uses: "./.github/actions/post-steps"
   # ========================= MacOS build only ======================== #
   build-macos:
-    if: ${{ github.repository_owner == 'facebook' }}
+    if: false
     runs-on: macos-15-xlarge
     env:
       ROCKSDB_DISABLE_JEMALLOC: 1
@@ -338,7 +342,7 @@ jobs:
     - uses: "./.github/actions/post-steps"
   # ========================= MacOS with Tests ======================== #
   build-macos-cmake:
-    if: ${{ github.repository_owner == 'facebook' }}
+    if: false
     runs-on: macos-15-xlarge
     strategy:
       matrix:
@@ -371,7 +375,7 @@ jobs:
   # ======================== Windows with Tests ======================= #
   # NOTE: some windows jobs are in "nightly" to save resources
   build-windows-vs2022:
-    if: ${{ github.repository_owner == 'facebook' }}
+    if: false
     runs-on: windows-8-core
     env:
       CMAKE_GENERATOR: Visual Studio 17 2022
@@ -381,7 +385,7 @@ jobs:
     - uses: "./.github/actions/windows-build-steps"
   # ============================ Java Jobs ============================ #
   build-linux-java:
-    if: ${{ github.repository_owner == 'facebook' }}
+    if: false
     runs-on:
       labels: 4-core-ubuntu
     container:
@@ -412,7 +416,7 @@ jobs:
       run: make V=1 J=8 -j8 jtest
     # post-steps skipped because of compatibility issues with docker image
   build-linux-java-static:
-    if: ${{ github.repository_owner == 'facebook' }}
+    if: false
     runs-on:
       labels: 4-core-ubuntu
     container:
@@ -443,7 +447,7 @@ jobs:
       run: make V=1 J=8 -j8 rocksdbjavastatic
     # post-steps skipped because of compatibility issues with docker image
   build-macos-java:
-    if: ${{ github.repository_owner == 'facebook' }}
+    if: false
     runs-on: macos-15-xlarge
     env:
       JAVA_HOME: "/Library/Java/JavaVirtualMachines/liberica-jdk-8.jdk/Contents/Home"
@@ -466,7 +470,7 @@ jobs:
       run: make V=1 J=16 -j16 jtest
     - uses: "./.github/actions/post-steps"
   build-macos-java-static:
-    if: ${{ github.repository_owner == 'facebook' }}
+    if: false
     runs-on: macos-15-xlarge
     env:
       JAVA_HOME: "/Library/Java/JavaVirtualMachines/liberica-jdk-8.jdk/Contents/Home"
@@ -488,7 +492,7 @@ jobs:
       run: make V=1 J=16 -j16 rocksdbjavastaticosx
     - uses: "./.github/actions/post-steps"
   build-macos-java-static-universal:
-    if: ${{ github.repository_owner == 'facebook' }}
+    if: false
     runs-on: macos-15-xlarge
     env:
       JAVA_HOME: "/Library/Java/JavaVirtualMachines/liberica-jdk-8.jdk/Contents/Home"
@@ -510,7 +514,7 @@ jobs:
       run: make V=1 J=16 -j16 rocksdbjavastaticosx_ub
     - uses: "./.github/actions/post-steps"
   build-linux-java-pmd:
-    if: ${{ github.repository_owner == 'facebook' }}
+    if: false
     runs-on:
       labels: 4-core-ubuntu
     container:
@@ -536,7 +540,7 @@ jobs:
         name: maven-site
         path: "${{ github.workspace }}/java/target/site"
   build-linux-arm:
-    if: ${{ github.repository_owner == 'facebook' }}
+    if: false
     runs-on:
       labels: 4-core-ubuntu-arm
     steps:

--- a/db/c.cc
+++ b/db/c.cc
@@ -536,12 +536,41 @@ rocksdb_table_properties_collector_context_get_last_level_inclusive_max_seqno_th
 
 const char* rocksdb_table_properties_get_user_collected_property(
     const rocksdb_table_properties_t* table_properties, const char* key) {
-  auto properties = table_properties->rep->user_collected_properties;
-  auto it = properties.find(std::string(key));
+  const UserCollectedProperties& properties =
+      table_properties->rep->user_collected_properties;
+  auto it = properties.find(key);
   if (it != properties.end()) {
-    return strdup(it->second.c_str());
+    return it->second.c_str();
   }
   return nullptr;
+}
+
+const char** rocksdb_table_properties_get_user_collected_property_keys(
+    const rocksdb_table_properties_t* table_properties, const char* prefix,
+    size_t* key_count) {
+  const UserCollectedProperties& properties =
+      table_properties->rep->user_collected_properties;
+
+  std::vector<const char*> matches;
+  for (auto pos = properties.lower_bound(prefix);
+       pos != properties.end() &&
+       pos->first.compare(0, strlen(prefix), prefix) == 0;
+       ++pos) {
+    matches.push_back(pos->first.c_str());
+  }
+
+  *key_count = matches.size();
+
+  if (matches.empty()) {
+    return nullptr;
+  }
+
+  const char** keys =
+      static_cast<const char**>(malloc(matches.size() * sizeof(char*)));
+  for (size_t i = 0; i < matches.size(); i++) {
+    keys[i] = matches[i];
+  }
+  return keys;
 }
 
 void rocksdb_table_properties_destroy(

--- a/db/c.cc
+++ b/db/c.cc
@@ -11,6 +11,7 @@
 
 #include <cstdlib>
 #include <map>
+#include <memory>
 #include <unordered_set>
 #include <vector>
 
@@ -35,6 +36,7 @@
 #include "rocksdb/statistics.h"
 #include "rocksdb/status.h"
 #include "rocksdb/table.h"
+#include "rocksdb/table_properties.h"
 #include "rocksdb/universal_compaction.h"
 #include "rocksdb/utilities/backup_engine.h"
 #include "rocksdb/utilities/checkpoint.h"
@@ -79,6 +81,7 @@ using ROCKSDB_NAMESPACE::CuckooTableOptions;
 using ROCKSDB_NAMESPACE::DB;
 using ROCKSDB_NAMESPACE::DBOptions;
 using ROCKSDB_NAMESPACE::DbPath;
+using ROCKSDB_NAMESPACE::EntryType;
 using ROCKSDB_NAMESPACE::Env;
 using ROCKSDB_NAMESPACE::EnvOptions;
 using ROCKSDB_NAMESPACE::EventListener;
@@ -119,6 +122,7 @@ using ROCKSDB_NAMESPACE::Range;
 using ROCKSDB_NAMESPACE::RateLimiter;
 using ROCKSDB_NAMESPACE::ReadOptions;
 using ROCKSDB_NAMESPACE::RestoreOptions;
+using ROCKSDB_NAMESPACE::SequenceNumber;
 using ROCKSDB_NAMESPACE::SequentialFile;
 using ROCKSDB_NAMESPACE::Slice;
 using ROCKSDB_NAMESPACE::SliceParts;
@@ -130,12 +134,15 @@ using ROCKSDB_NAMESPACE::SstFileWriter;
 using ROCKSDB_NAMESPACE::Status;
 using ROCKSDB_NAMESPACE::StderrLogger;
 using ROCKSDB_NAMESPACE::SubcompactionJobInfo;
+using ROCKSDB_NAMESPACE::TableProperties;
+using ROCKSDB_NAMESPACE::TablePropertiesCollector;
 using ROCKSDB_NAMESPACE::TablePropertiesCollectorFactory;
 using ROCKSDB_NAMESPACE::Transaction;
 using ROCKSDB_NAMESPACE::TransactionDB;
 using ROCKSDB_NAMESPACE::TransactionDBOptions;
 using ROCKSDB_NAMESPACE::TransactionLogIterator;
 using ROCKSDB_NAMESPACE::TransactionOptions;
+using ROCKSDB_NAMESPACE::UserCollectedProperties;
 using ROCKSDB_NAMESPACE::WaitForCompactOptions;
 using ROCKSDB_NAMESPACE::WALRecoveryMode;
 using ROCKSDB_NAMESPACE::WritableFile;
@@ -381,6 +388,174 @@ struct rocksdb_compactionfilter_t : public CompactionFilter {
 
   bool IgnoreSnapshots() const override { return ignore_snapshots_; }
 };
+
+/* Table Properties */
+
+struct rocksdb_table_properties_t {
+  const TableProperties* rep;
+};
+
+struct rocksdb_table_properties_collector_factory_context_t {
+  TablePropertiesCollectorFactory::Context* rep;
+};
+
+struct rocksdb_user_collected_properties_t {
+  UserCollectedProperties* rep;
+};
+
+struct rocksdb_table_properties_collector_t : public TablePropertiesCollector {
+  void* state_;
+  void (*destructor_)(void*);
+  bool (*add_user_key_)(void*, const char* key, size_t key_len,
+                        const char* value, size_t value_len, int entry_type,
+                        uint64_t sequence_number, uint64_t file_size);
+  void (*block_add_)(void*, uint64_t, uint64_t, uint64_t);
+  bool (*finish_)(void*, rocksdb_user_collected_properties_t* properties);
+  void (*get_readable_properties_)(
+      void*, rocksdb_user_collected_properties_t* properties);
+  const char* (*name_)(void*);
+
+  rocksdb_table_properties_collector_t(
+      void* state, void (*destructor)(void*),
+      bool (*add_user_key)(void*, const char* key, size_t key_len,
+                           const char* value, size_t value_len, int entry_type,
+                           uint64_t sequence_number, uint64_t file_size),
+      void (*block_add)(void*, uint64_t, uint64_t, uint64_t),
+      bool (*finish)(void*, rocksdb_user_collected_properties_t* properties),
+      void (*get_readable_properties)(
+          void*, rocksdb_user_collected_properties_t* properties),
+      const char* (*name)(void*)) {
+    state_ = state;
+    destructor_ = destructor;
+    add_user_key_ = add_user_key;
+    block_add_ = block_add;
+    finish_ = finish;
+    get_readable_properties_ = get_readable_properties;
+    name_ = name;
+  }
+
+  ~rocksdb_table_properties_collector_t() override { (*destructor_)(state_); }
+
+  Status AddUserKey(const Slice& key, const Slice& value, EntryType entry_type,
+                    SequenceNumber seq, uint64_t file_size) override {
+    bool result = (*add_user_key_)(state_, key.data(), key.size(), value.data(),
+                                   value.size(), entry_type, seq, file_size);
+    if (result) {
+      return Status::OK();
+    } else {
+      return Status::Aborted();
+    }
+  }
+
+  void BlockAdd(uint64_t block_uncomp_bytes,
+                uint64_t block_compressed_bytes_fast,
+                uint64_t block_compressed_bytes_slow) override {
+    if (block_add_ != nullptr) {
+      (*block_add_)(state_, block_uncomp_bytes, block_compressed_bytes_fast,
+                    block_compressed_bytes_slow);
+    }
+  }
+
+  Status Finish(UserCollectedProperties* properties) override {
+    rocksdb_user_collected_properties_t user_collected_properties;
+    user_collected_properties.rep = properties;
+    bool result = (*finish_)(state_, &user_collected_properties);
+    if (result) {
+      return Status::OK();
+    } else {
+      return Status::Aborted();
+    }
+  }
+
+  UserCollectedProperties GetReadableProperties() const override {
+    UserCollectedProperties properties;
+    rocksdb_user_collected_properties_t user_collected_properties;
+    user_collected_properties.rep = &properties;
+    (*get_readable_properties_)(state_, &user_collected_properties);
+    return properties;
+  }
+
+  const char* Name() const override { return (*name_)(state_); }
+};
+
+struct rocksdb_table_properties_collector_factory_t
+    : public TablePropertiesCollectorFactory {
+  void* state_;
+  void (*destructor_)(void*);
+  rocksdb_table_properties_collector_t* (*create_table_properties_collector_)(
+      void*, rocksdb_table_properties_collector_context_t*);
+  const char* (*name_)(void*);
+
+  rocksdb_table_properties_collector_factory_t(
+      void* state, void (*destructor)(void*),
+      rocksdb_table_properties_collector_t* (
+          *create_table_properties_collector)(
+          void*, rocksdb_table_properties_collector_context_t*),
+      const char* (*name)(void*)) {
+    this->state_ = state;
+    this->destructor_ = destructor;
+    this->create_table_properties_collector_ =
+        create_table_properties_collector;
+    this->name_ = name;
+  }
+
+  ~rocksdb_table_properties_collector_factory_t() override {
+    (*destructor_)(state_);
+  }
+
+  TablePropertiesCollector* CreateTablePropertiesCollector(
+      TablePropertiesCollectorFactory::Context context) override {
+    rocksdb_table_properties_collector_context_t cb_context;
+    cb_context.rep = &context;
+    return (*create_table_properties_collector_)(state_, &cb_context);
+  }
+
+  const char* Name() const override { return (*name_)(state_); }
+};
+
+uint32_t rocksdb_table_properties_collector_context_get_column_family_id(
+    rocksdb_table_properties_collector_context_t* context) {
+  return context->rep->column_family_id;
+}
+
+int rocksdb_table_properties_collector_context_get_level_at_creation(
+    rocksdb_table_properties_collector_context_t* context) {
+  return context->rep->level_at_creation;
+}
+
+int rocksdb_table_properties_collector_context_get_num_levels(
+    rocksdb_table_properties_collector_context_t* context) {
+  return context->rep->num_levels;
+}
+
+uint64_t
+rocksdb_table_properties_collector_context_get_last_level_inclusive_max_seqno_threshold(
+    rocksdb_table_properties_collector_context_t* context) {
+  return context->rep->last_level_inclusive_max_seqno_threshold;
+}
+
+const char* rocksdb_table_properties_get_user_collected_property(
+    const rocksdb_table_properties_t* table_properties, const char* key) {
+  auto properties = table_properties->rep->user_collected_properties;
+  auto it = properties.find(std::string(key));
+  if (it != properties.end()) {
+    return strdup(it->second.c_str());
+  }
+  return nullptr;
+}
+
+void rocksdb_table_properties_destroy(
+    const rocksdb_table_properties_t* table_properties) {
+  delete table_properties;
+}
+
+void rocksdb_user_collected_properties_insert(
+    rocksdb_user_collected_properties_t* properties, const char* key,
+    const char* value) {
+  properties->rep->emplace(std::string(key), std::string(value));
+}
+
+/* Compaction Filter Factory */
 
 struct rocksdb_compactionfilterfactory_t : public CompactionFilterFactory {
   void* state_;
@@ -3224,6 +3399,13 @@ uint32_t rocksdb_flushjobinfo_flush_reason(const rocksdb_flushjobinfo_t* info) {
   return static_cast<uint32_t>(info->rep.flush_reason);
 }
 
+const rocksdb_table_properties_t* rocksdb_flushjobinfo_table_properties(
+    const rocksdb_flushjobinfo_t* info) {
+  auto table_properties = new rocksdb_table_properties_t;
+  table_properties->rep = &info->rep.table_properties;
+  return table_properties;
+}
+
 void rocksdb_reset_status(rocksdb_status_ptr_t* status_ptr) {
   auto ptr = status_ptr->rep;
   *ptr = Status::OK();
@@ -3667,6 +3849,31 @@ void rocksdb_options_set_comparator(rocksdb_options_t* opt,
 void rocksdb_options_set_merge_operator(
     rocksdb_options_t* opt, rocksdb_mergeoperator_t* merge_operator) {
   opt->rep.merge_operator = std::shared_ptr<MergeOperator>(merge_operator);
+}
+
+rocksdb_table_properties_collector_t* rocksdb_table_properties_collector_create(
+    void* state, void (*destructor)(void* state),
+    bool (*add_user_key)(void*, const char* key, size_t key_len,
+                         const char* value, size_t value_len, int entry_type,
+                         uint64_t sequence_number, uint64_t file_size),
+    void (*block_add)(void*, uint64_t, uint64_t, uint64_t),
+    bool (*finish)(void*, rocksdb_user_collected_properties_t* properties),
+    void (*get_readable_properties)(
+        void*, rocksdb_user_collected_properties_t* properties),
+    const char* (*name)(void*)) {
+  return new rocksdb_table_properties_collector_t(
+      state, destructor, add_user_key, block_add, finish,
+      get_readable_properties, name);
+}
+
+void rocksdb_options_add_table_properties_collector_factory(
+    rocksdb_options_t* options, void* state, void (*destructor)(void* state),
+    const char* (*name)(void*),
+    rocksdb_table_properties_collector_t* (*create_collector)(
+        void* state, rocksdb_table_properties_collector_context_t* context)) {
+  auto factory = std::make_shared<rocksdb_table_properties_collector_factory_t>(
+      state, destructor, create_collector, name);
+  options->rep.table_properties_collector_factories.emplace_back(factory);
 }
 
 void rocksdb_options_set_create_if_missing(rocksdb_options_t* opt,
@@ -5111,7 +5318,6 @@ DB::GetOptions
 DB::GetSortedWalFiles
 DB::RunManualCompaction
 custom cache
-table_properties_collectors
 */
 
 rocksdb_compactionfilter_t* rocksdb_compactionfilter_create(

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -86,6 +86,13 @@ typedef struct rocksdb_compactionfiltercontext_t
     rocksdb_compactionfiltercontext_t;
 typedef struct rocksdb_compactionfilterfactory_t
     rocksdb_compactionfilterfactory_t;
+typedef struct rocksdb_table_properties_t rocksdb_table_properties_t;
+typedef struct rocksdb_user_collected_properties_t
+    rocksdb_user_collected_properties_t;
+typedef struct rocksdb_table_properties_collector_t
+    rocksdb_table_properties_collector_t;
+typedef struct rocksdb_table_properties_collector_factory_context_t
+    rocksdb_table_properties_collector_context_t;
 typedef struct rocksdb_comparator_t rocksdb_comparator_t;
 typedef struct rocksdb_dbpath_t rocksdb_dbpath_t;
 typedef struct rocksdb_env_t rocksdb_env_t;
@@ -1225,6 +1232,8 @@ extern ROCKSDB_LIBRARY_API uint32_t
 rocksdb_flushjobinfo_flush_reason(const rocksdb_flushjobinfo_t* info);
 extern ROCKSDB_LIBRARY_API void rocksdb_status_ptr_get_error(
     rocksdb_status_ptr_t* status, char** errptr);
+extern ROCKSDB_LIBRARY_API const rocksdb_table_properties_t*
+rocksdb_flushjobinfo_table_properties(const rocksdb_flushjobinfo_t*);
 
 /* Compaction job info */
 extern ROCKSDB_LIBRARY_API void rocksdb_compactionjobinfo_status(
@@ -1967,6 +1976,50 @@ extern ROCKSDB_LIBRARY_API unsigned char rocksdb_options_get_atomic_flush(
 
 extern ROCKSDB_LIBRARY_API void rocksdb_options_set_row_cache(
     rocksdb_options_t* opt, rocksdb_cache_t* cache);
+
+extern ROCKSDB_LIBRARY_API void
+rocksdb_options_add_table_properties_collector_factory(
+    rocksdb_options_t* options, void* state, void (*destructor)(void* state),
+    const char* (*name)(void*),
+    rocksdb_table_properties_collector_t* (*create_collector)(
+        void* state, rocksdb_table_properties_collector_context_t* context));
+
+extern ROCKSDB_LIBRARY_API rocksdb_table_properties_collector_t*
+rocksdb_table_properties_collector_create(
+    void* state, void (*destructor)(void* state),
+    bool (*add_user_key)(void*, const char* key, size_t key_len,
+                         const char* value, size_t value_len, int entry_type,
+                         uint64_t sequence_number, uint64_t file_size),
+    void (*block_add)(void*, uint64_t, uint64_t, uint64_t),
+    bool (*finish)(void*, rocksdb_user_collected_properties_t* properties),
+    void (*get_readable_properties)(
+        void*, rocksdb_user_collected_properties_t* properties),
+    const char* (*name)(void*));
+
+extern ROCKSDB_LIBRARY_API uint32_t
+rocksdb_table_properties_collector_context_get_column_family_id(
+    rocksdb_table_properties_collector_context_t*);
+
+extern ROCKSDB_LIBRARY_API int
+rocksdb_table_properties_collector_context_get_level_at_creation(
+    rocksdb_table_properties_collector_context_t*);
+
+extern ROCKSDB_LIBRARY_API int
+rocksdb_table_properties_collector_context_get_num_levels(
+    rocksdb_table_properties_collector_context_t*);
+
+extern ROCKSDB_LIBRARY_API uint64_t
+rocksdb_table_properties_collector_context_get_last_level_inclusive_max_seqno_threshold(
+    rocksdb_table_properties_collector_context_t*);
+
+extern ROCKSDB_LIBRARY_API const char*
+rocksdb_table_properties_get_user_collected_property(
+    const rocksdb_table_properties_t* table_properties, const char* key);
+extern ROCKSDB_LIBRARY_API void rocksdb_table_properties_destroy(
+    const rocksdb_table_properties_t*);
+
+extern ROCKSDB_LIBRARY_API void rocksdb_user_collected_properties_insert(
+    rocksdb_user_collected_properties_t*, const char*, const char*);
 
 extern ROCKSDB_LIBRARY_API void
 rocksdb_options_add_compact_on_deletion_collector_factory(

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -2015,6 +2015,10 @@ rocksdb_table_properties_collector_context_get_last_level_inclusive_max_seqno_th
 extern ROCKSDB_LIBRARY_API const char*
 rocksdb_table_properties_get_user_collected_property(
     const rocksdb_table_properties_t* table_properties, const char* key);
+extern ROCKSDB_LIBRARY_API const char**
+rocksdb_table_properties_get_user_collected_property_keys(
+    const rocksdb_table_properties_t* table_properties, const char* prefix,
+    size_t* key_count);
 extern ROCKSDB_LIBRARY_API void rocksdb_table_properties_destroy(
     const rocksdb_table_properties_t*);
 


### PR DESCRIPTION
Brings rust-rocksdb fork up to date with latest upstream required by v0.45 - see https://github.com/restatedev/rust-rocksdb/pull/17 for the Rust bindings update.