### PR TITLE
Add rocksdb_readoptions_set_table_filter to C API

### DIFF
--- a/db/c.cc
+++ b/db/c.cc
@@ -5765,6 +5765,21 @@ void rocksdb_readoptions_set_auto_readahead_size(rocksdb_readoptions_t* opt,
   opt->rep.auto_readahead_size = v;
 }
 
+void rocksdb_readoptions_set_table_filter(
+    rocksdb_readoptions_t* opt, void* state,
+    unsigned char (*table_filter)(void*,
+                                  const rocksdb_table_properties_t*),
+    void (*destroy)(void*)) {
+  auto shared_state =
+      std::shared_ptr<void>(state, destroy ? destroy : [](void*) {});
+  opt->rep.table_filter =
+      [shared_state, table_filter](const TableProperties& props) -> bool {
+    rocksdb_table_properties_t c_props;
+    c_props.rep = &props;
+    return table_filter(shared_state.get(), &c_props);
+  };
+}
+
 rocksdb_writeoptions_t* rocksdb_writeoptions_create() {
   return new rocksdb_writeoptions_t;
 }

--- a/include/rocksdb/c.h
+++ b/include/rocksdb/c.h
@@ -2350,6 +2350,11 @@ extern ROCKSDB_LIBRARY_API void rocksdb_readoptions_set_iter_start_ts(
 extern ROCKSDB_LIBRARY_API void rocksdb_readoptions_set_auto_readahead_size(
     rocksdb_readoptions_t*, unsigned char);
 
+extern ROCKSDB_LIBRARY_API void rocksdb_readoptions_set_table_filter(
+    rocksdb_readoptions_t*, void* state,
+    unsigned char (*table_filter)(void*, const rocksdb_table_properties_t*),
+    void (*destroy)(void*));
+
 /* Write options */
 
 extern ROCKSDB_LIBRARY_API rocksdb_writeoptions_t* rocksdb_writeoptions_create(


### PR DESCRIPTION
Expose ReadOptions::table_filter through the C API. The new function accepts a state pointer, a filter callback, and a destructor. The implementation wraps these into a std::function lambda assigned to rep.table_filter, using shared_ptr for lifetime management.